### PR TITLE
fix: switch App Service Plan from Y1/Dynamic to B1/Basic

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,11 @@ Only **one person** in your group needs to run the deploy. Everyone else just se
 | Resource | Estimated monthly cost |
 |---|---|
 | Cosmos DB (serverless) | ~$0–$1 for light use |
-| Azure Functions (Y1/consumption) | Free for light use |
+| App Service Plan (B1 Basic) | ~$13/month |
 | Storage Account | < $0.10 |
-| **Total** | **< $2/month** for a small group |
+| **Total** | **~$13–$14/month** |
+
+> The Bicep uses a **Basic B1** dedicated plan rather than the consumption (Y1/Dynamic) tier. Many personal/trial Azure subscriptions have a Dynamic VM quota of 0, which blocks the consumption plan. B1 avoids that restriction entirely.
 
 -----
 

--- a/infra/deploy.sh
+++ b/infra/deploy.sh
@@ -16,7 +16,7 @@ BICEP_FILE="${SCRIPT_DIR}/main.bicep"
 FUNC_SRC_DIR="${REPO_ROOT}/leaderboard_api"
 
 echo "========================================================"
-echo " F1 Lap Tracker — Community Leaderboard Deploy"
+echo " Pitwall IQ — Community Leaderboard Deploy"
 echo "========================================================"
 echo " Resource Group : ${RESOURCE_GROUP}"
 echo " Location       : ${LOCATION}"

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -107,15 +107,15 @@ resource cosmosContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
 }
 
 // ---------------------------------------------------------------------------
-// App Service Plan — Consumption (Y1/Dynamic), Linux
+// App Service Plan — Basic B1, Linux (dedicated; avoids Dynamic VM quota)
 // ---------------------------------------------------------------------------
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2023-01-01' = {
   name: '${baseName}-plan'
   location: location
   sku: {
-    name: 'Y1'
-    tier: 'Dynamic'
+    name: 'B1'
+    tier: 'Basic'
   }
   kind: 'linux'
   properties: {
@@ -156,6 +156,7 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
           value: cosmosAccount.listConnectionStrings().connectionStrings[0].connectionString
         }
       ]
+      alwaysOn: true   // Required for dedicated (non-consumption) plans
       ftpsState: 'Disabled'
       minTlsVersion: '1.2'
     }


### PR DESCRIPTION
Fixes the `Unauthorized / Dynamic VMs quota = 0` error that blocks deployment on personal and trial Azure subscriptions.

## Changes

- **`infra/main.bicep`** — App Service Plan SKU changed from `Y1`/`Dynamic` (consumption) to `B1`/`Basic` (dedicated). Added `alwaysOn: true` to the Function App site config, which is required for dedicated plans.
- **`infra/deploy.sh`** — Banner updated to say "Pitwall IQ".
- **`README.md`** — Cost estimate updated to reflect B1 (~$13–14/month) with a note explaining why B1 is used.

## Why B1 and not Y1?

The Y1 consumption plan uses "Dynamic VMs" under the hood. Many personal/trial Azure subscriptions have a quota of 0 for Dynamic VMs, causing this error during deployment even though the numbers in the error message show 0. B1 is a standard dedicated Linux VM that doesn't require any special quota.

## Cost impact

| Before | After |
|---|---|
| Y1/Dynamic: ~$0–2/month (but blocked) | B1/Basic: ~$13/month (works) |

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS