### PR TITLE
fix: final lap capture, session close, leaderboard double /api bug

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -36,6 +36,10 @@ import os
 
 # ── Leaderboard config (set via environment variables) ────────────────────────
 LEADERBOARD_URL = os.environ.get("F1_LEADERBOARD_URL", "").rstrip("/")
+# Normalise: strip trailing /api so the URL works whether or not the user
+# included it (the code appends /api/submit etc. itself).
+if LEADERBOARD_URL.endswith("/api"):
+    LEADERBOARD_URL = LEADERBOARD_URL[:-4]
 LEADERBOARD_KEY = os.environ.get("F1_LEADERBOARD_KEY", "")
 
 # ── Azure OpenAI config (set via environment variables) ───────────────────────

--- a/README.md
+++ b/README.md
@@ -258,14 +258,14 @@ The script will:
 
 **Linux / macOS:**
 ```bash
-export F1_LEADERBOARD_URL="https://<your-func>.azurewebsites.net/api"
+export F1_LEADERBOARD_URL="https://<your-func>.azurewebsites.net"
 export F1_LEADERBOARD_KEY="<your-function-key>"
 python F1_lap_tracker.py
 ```
 
 **Windows (PowerShell):**
 ```powershell
-$env:F1_LEADERBOARD_URL = "https://<your-func>.azurewebsites.net/api"
+$env:F1_LEADERBOARD_URL = "https://<your-func>.azurewebsites.net"
 $env:F1_LEADERBOARD_KEY = "<your-function-key>"
 python F1_lap_tracker.py
 ```


### PR DESCRIPTION
Four fixes from real-world testing.

## Bug 1 — Final lap not recorded
The last lap in a race was never saved. The trigger `cur_lap_num > prev_lap` never fires on the final lap — the race ends so there's no next lap to start and the counter stays the same.

Added a secondary trigger: if `last_lap_ms` changes to a value not yet recorded, save the lap regardless of whether the counter incremented. `last_recorded_lap_ms` in state prevents double-counting and resets on Clear Session.

## Bug 2 — Session stays "In Progress" after stopping the tracker
`db_close_session()` was only called from the Clear Session button. Stopping with Ctrl+C left `ended_at` as NULL. Fixed by closing the open session in the `KeyboardInterrupt` handler in `main()`.

## Bug 3 — Leaderboard submissions silently failing (double /api)
The README instructed users to set `F1_LEADERBOARD_URL` with `/api` on the end, but the code also appends `/api/submit` and `/api/leaderboard` — resulting in every submission hitting `.../api/api/submit` which 404s silently.

Fixed by normalising `LEADERBOARD_URL` at startup to strip a trailing `/api` if present, so it works regardless of how the user set it. README examples updated to show the URL without `/api`.

## Bug 4 — Azure Function App returns 403 on dedicated plan
Missing `WEBSITE_RUN_FROM_PACKAGE=1` app setting caused the Functions runtime to not discover any functions on a B1 dedicated plan. Added to Bicep. Also fixed the deploy.sh banner to say "Pitwall IQ".

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS