### PR TITLE
fix: widen sidebar for leaderboard readability

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -899,7 +899,7 @@ display: flex;
 align-items: flex-start;
 }
 .sidebar {
-width: 260px;
+width: 320px;
 flex-shrink: 0;
 position: sticky;
 top: 0;


### PR DESCRIPTION
## Summary

- Widens the sidebar from 260px to 320px, giving the community leaderboard table an extra 60px of content width to prevent columns from being squished

## Test plan
- [ ] Leaderboard columns (#, TIME, TYRE, DRIVER) display without crowding in the sidebar

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS