### PR TITLE
feat: career stats tab + IP rate limiting on debrief endpoint

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -90,6 +90,9 @@ state = {
     "current_sector": 0,               # 0=S1, 1=S2, 2=S3
     "lap_trace": [],                   # [{x,z,speed,throttle,brake,gear,gLat,gLon,sector}] current lap
     "track_outline": [],               # reference trace from last completed lap
+    "career_stats": {"races":0,"wins":0,"podiums":0,"points":0,"fastest_laps":0,"dnfs":0},
+    "race_result": None,               # populated when Final Classification packet (ID 8) arrives
+    "player_fastest_lap": False,       # set True when FTLP event fires for the player
 }
 
 TRACK_IDS = {
@@ -149,6 +152,9 @@ WEATHER_IDS = {0:"Clear", 1:"Light Cloud", 2:"Overcast", 3:"Light Rain",
 
 VISUAL_COMPOUNDS = {7:"Inter", 8:"Wet", 16:"Soft", 17:"Medium", 18:"Hard"}
 
+FINAL_CLASS_SIZE = 45   # bytes per car in PacketFinalClassificationData
+RESULT_STATUS    = {0:"Invalid",1:"Inactive",2:"Active",3:"Finished",4:"DNF",5:"DSQ",6:"N/C",7:"Retired"}
+
 # ── SQLite persistence ────────────────────────────────────────────────────────
 
 DB_PATH = "f1_laps.db"
@@ -197,6 +203,24 @@ def init_db():
             set_at       TEXT,
             session_id   INTEGER,
             PRIMARY KEY (track, session_type)
+        )
+    """)
+    con.execute("""
+        CREATE TABLE IF NOT EXISTS race_results (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id    INTEGER,
+            track         TEXT,
+            session_type  TEXT,
+            position      INTEGER,
+            grid_pos      INTEGER,
+            points        INTEGER,
+            num_laps      INTEGER,
+            result_status INTEGER,
+            best_lap_ms   INTEGER,
+            best_lap      TEXT,
+            total_time_s  REAL,
+            fastest_lap   INTEGER DEFAULT 0,
+            recorded_at   TEXT
         )
     """)
     # Migrations for existing databases
@@ -280,6 +304,49 @@ def db_get_all_pbs():
     con.row_factory = sqlite3.Row
     rows = con.execute(
         "SELECT * FROM personal_bests ORDER BY track, session_type"
+    ).fetchall()
+    con.close()
+    return [dict(r) for r in rows]
+
+def db_save_race_result(session_id, track, session_type, position, grid_pos,
+                        points, num_laps, result_status, best_lap_ms, best_lap,
+                        total_time_s, fastest_lap):
+    con = sqlite3.connect(DB_PATH)
+    con.execute(
+        """INSERT INTO race_results
+           (session_id, track, session_type, position, grid_pos, points, num_laps,
+            result_status, best_lap_ms, best_lap, total_time_s, fastest_lap, recorded_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+        (session_id, track, session_type, position, grid_pos, points, num_laps,
+         result_status, best_lap_ms, best_lap, total_time_s, int(fastest_lap),
+         datetime.now().isoformat()),
+    )
+    con.commit()
+    con.close()
+
+def db_get_career_stats():
+    con = sqlite3.connect(DB_PATH)
+    row = con.execute("""
+        SELECT
+            COUNT(*)                                                      AS races,
+            SUM(CASE WHEN position = 1 AND result_status = 3 THEN 1 ELSE 0 END) AS wins,
+            SUM(CASE WHEN position <= 3 AND result_status = 3 THEN 1 ELSE 0 END) AS podiums,
+            SUM(points)                                                   AS points,
+            SUM(fastest_lap)                                              AS fastest_laps,
+            SUM(CASE WHEN result_status IN (4,7) THEN 1 ELSE 0 END)      AS dnfs
+        FROM race_results
+    """).fetchone()
+    con.close()
+    if row:
+        return {"races": row[0] or 0, "wins": row[1] or 0, "podiums": row[2] or 0,
+                "points": row[3] or 0, "fastest_laps": row[4] or 0, "dnfs": row[5] or 0}
+    return {"races": 0, "wins": 0, "podiums": 0, "points": 0, "fastest_laps": 0, "dnfs": 0}
+
+def db_get_recent_races(limit=30):
+    con = sqlite3.connect(DB_PATH)
+    con.row_factory = sqlite3.Row
+    rows = con.execute(
+        "SELECT * FROM race_results ORDER BY id DESC LIMIT ?", (limit,)
     ).fetchall()
     con.close()
     return [dict(r) for r in rows]
@@ -659,6 +726,69 @@ def parse_car_status_packet(data, player_idx):
     except Exception:
         pass
 
+# Packet ID 3 – Event Data
+def parse_event_packet(data, player_idx):
+    try:
+        base = HEADER_SIZE
+        if len(data) < base + 4:
+            return
+        code = data[base:base + 4].decode("ascii", errors="ignore")
+        if code == "FTLP" and len(data) >= base + 5:
+            vehicle_idx = struct.unpack_from("<B", data, base + 4)[0]
+            if vehicle_idx == player_idx:
+                with state_lock:
+                    state["player_fastest_lap"] = True
+    except Exception:
+        pass
+
+# Packet ID 8 – Final Classification Data
+def parse_final_classification_packet(data, player_idx):
+    try:
+        base = HEADER_SIZE
+        if len(data) < base + 1:
+            return
+        num_cars = struct.unpack_from("<B", data, base)[0]
+        if player_idx >= num_cars:
+            return
+        car_base = base + 1 + player_idx * FINAL_CLASS_SIZE
+        if len(data) < car_base + 20:
+            return
+        position      = struct.unpack_from("<B", data, car_base + 0)[0]
+        num_laps      = struct.unpack_from("<B", data, car_base + 1)[0]
+        grid_pos      = struct.unpack_from("<B", data, car_base + 2)[0]
+        points        = struct.unpack_from("<B", data, car_base + 3)[0]
+        result_status = struct.unpack_from("<B", data, car_base + 5)[0]
+        best_lap_ms   = struct.unpack_from("<I", data, car_base + 6)[0]
+        total_time_s  = struct.unpack_from("<d", data, car_base + 10)[0]
+        best_lap_str  = ms_to_laptime(best_lap_ms) if best_lap_ms > 0 else "—"
+        with state_lock:
+            fastest  = state["player_fastest_lap"]
+            state["player_fastest_lap"] = False
+            sid      = state["current_session_id"]
+            track    = state["session"]["track"]
+            sess_type = state["session"]["session_type"]
+            state["race_result"] = {
+                "position": position,
+                "grid_pos": grid_pos,
+                "points": points,
+                "num_laps": num_laps,
+                "result_status": result_status,
+                "best_lap_ms": best_lap_ms,
+                "best_lap": best_lap_str,
+                "total_time_s": round(total_time_s, 3),
+                "fastest_lap": fastest,
+                "track": track,
+                "session_type": sess_type,
+            }
+        db_save_race_result(sid, track, sess_type, position, grid_pos, points,
+                            num_laps, result_status, best_lap_ms, best_lap_str,
+                            total_time_s, fastest)
+        stats = db_get_career_stats()
+        with state_lock:
+            state["career_stats"] = stats
+    except Exception:
+        pass
+
 # ── Community leaderboard ─────────────────────────────────────────────────────
 
 def _lb_post(payload):
@@ -762,6 +892,10 @@ def udp_listener():
                 parse_car_status_packet(data, pidx)
             elif pid == 0:
                 parse_motion_packet(data, pidx)
+            elif pid == 3:
+                parse_event_packet(data, pidx)
+            elif pid == 8:
+                parse_final_classification_packet(data, pidx)
         except socket.timeout:
             pass
         except Exception:
@@ -1103,6 +1237,20 @@ transition: border-color .2s;
 
 /* Sector mini-best highlight */
 td.sector.s-best { background: rgba(167,139,250,.18); color: var(--purple) !important; font-weight: 700; border-radius: 3px; }
+/* Tabs */
+.tab-bar { display:flex; gap:0; margin-bottom:12px; border-bottom:1px solid var(--border); }
+.tab { background:none; border:none; border-bottom:2px solid transparent; color:var(--muted); font-family:'Orbitron',sans-serif; font-size:.7rem; letter-spacing:.1em; padding:9px 20px; cursor:pointer; margin-bottom:-1px; transition:color .15s; }
+.tab.active { color:var(--red); border-bottom-color:var(--red); }
+.tab:hover:not(.active) { color:var(--text); }
+/* Career panel */
+.career-summary { display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
+.stat-box { flex:1; min-width:72px; background:rgba(255,255,255,.04); border-radius:4px; padding:10px 8px; text-align:center; }
+.stat-val { font-family:'Orbitron',sans-serif; font-size:1.3rem; font-weight:700; color:var(--text); }
+.stat-lbl { font-size:.6rem; color:var(--muted); letter-spacing:.1em; margin-top:3px; }
+.fl-badge { background:var(--purple); color:#fff; font-size:.6rem; padding:1px 5px; border-radius:2px; margin-right:4px; font-weight:700; vertical-align:middle; }
+td.finish-gold { color:#ffd700; font-weight:700; }
+td.finish-silver { color:#c0c0c0; font-weight:700; }
+td.finish-bronze { color:#cd7f32; font-weight:700; }
 
 /* Toast notifications */
 #toast-container { position:fixed; top:20px; right:20px; z-index:9999; display:flex; flex-direction:column; gap:8px; pointer-events:none; }
@@ -1260,6 +1408,11 @@ transition: border-color .2s, color .2s;
     <div id="lb-section"></div>
   </aside>
   <div class="main-col">
+    <div class="tab-bar">
+      <button class="tab active" id="tab-btn-session" onclick="switchTab('session')">SESSION</button>
+      <button class="tab" id="tab-btn-career" onclick="switchTab('career')">CAREER</button>
+    </div>
+    <div id="tab-session">
     <div id="comp-bar">
       <span class="comp-tag-a" id="comp-label-a">A: —</span>
       <span style="color:var(--muted)">vs</span>
@@ -2544,8 +2697,10 @@ def main():
     print()
 
     cfg = init_config()
+    career = db_get_career_stats()
     with state_lock:
         state["player_id"]         = cfg["player_id"]
+        state["career_stats"]      = career
         state["leaderboard_opt_in"] = cfg["leaderboard_opt_in"]
         state["display_name"]      = cfg["display_name"]
         state["leaderboard_enabled"] = bool(LEADERBOARD_URL)

--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1442,10 +1442,78 @@ transition: border-color .2s, color .2s;
       <div id="sessions-section"></div>
     </div>
     <div id="debrief-section"></div>
+    </div><!-- end tab-session -->
+    <div id="tab-career" style="display:none">
+      <div id="career-section"></div>
+    </div>
   </div>
 </div>
 
 <script>
+// ── Tab system ────────────────────────────────────────────────────────────────
+function switchTab(name) {
+  document.getElementById('tab-session').style.display = name === 'session' ? '' : 'none';
+  document.getElementById('tab-career').style.display  = name === 'career'  ? '' : 'none';
+  document.querySelectorAll('.tab').forEach(t =>
+    t.classList.toggle('active', t.id === `tab-btn-${name}`)
+  );
+  if (name === 'career') loadCareer();
+}
+
+// ── Career stats ──────────────────────────────────────────────────────────────
+const RACE_STATUS = {0:'Invalid',1:'Inactive',2:'Active',3:'Finished',4:'DNF',5:'DSQ',6:'N/C',7:'Retired'};
+let _lastRaceResultTs = null;
+
+async function loadCareer() {
+  try {
+    const r = await fetch('/api/career');
+    const d = await r.json();
+    renderCareer(d);
+  } catch(e) {}
+}
+
+function renderCareer(d) {
+  const { stats, recent } = d;
+  const winPct = stats.races > 0 ? ((stats.wins / stats.races) * 100).toFixed(0) : 0;
+  const rows = recent.map(r => {
+    const pos = r.result_status === 3 ? r.position : null;
+    const finishTxt = pos ? `P${pos}` : (RACE_STATUS[r.result_status] || '?');
+    const finishCls = pos === 1 ? ' finish-gold' : pos === 2 ? ' finish-silver' : pos === 3 ? ' finish-bronze' : '';
+    const fl = r.fastest_lap ? '<span class="fl-badge">FL</span>' : '';
+    return `<tr>
+      <td>${esc(r.track)}</td>
+      <td style="color:var(--muted);font-size:.7rem">${esc(r.session_type)}</td>
+      <td class="num">${r.grid_pos || '—'}</td>
+      <td class="num${finishCls}">${finishTxt}</td>
+      <td class="num">${r.points}</td>
+      <td style="font-size:.7rem">${fl}${esc(r.best_lap || '—')}</td>
+    </tr>`;
+  }).join('');
+  const section = document.getElementById('career-section');
+  if (!section) return;
+  section.innerHTML = `
+    <div class="panel">
+      <div class="panel-title">CAREER STATS</div>
+      <div class="career-summary">
+        <div class="stat-box"><div class="stat-val">${stats.races}</div><div class="stat-lbl">RACES</div></div>
+        <div class="stat-box"><div class="stat-val">${stats.wins}</div><div class="stat-lbl">WINS</div></div>
+        <div class="stat-box"><div class="stat-val">${stats.podiums}</div><div class="stat-lbl">PODIUMS</div></div>
+        <div class="stat-box"><div class="stat-val">${stats.points}</div><div class="stat-lbl">POINTS</div></div>
+        <div class="stat-box"><div class="stat-val">${stats.fastest_laps}</div><div class="stat-lbl">FAST LAPS</div></div>
+        <div class="stat-box"><div class="stat-val">${stats.dnfs}</div><div class="stat-lbl">DNFs</div></div>
+      </div>
+      ${recent.length ? `
+        <div class="lap-table-wrap" style="margin-top:14px">
+          <table class="lap-table">
+            <thead><tr>
+              <th>TRACK</th><th>TYPE</th><th>GRID</th><th>FINISH</th><th>PTS</th><th>BEST LAP</th>
+            </tr></thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>` : '<p style="color:var(--muted);margin-top:12px;font-size:.8rem">No race results yet — finish a race session to start tracking your career.</p>'}
+    </div>`;
+}
+
 // ── Community leaderboard ─────────────────────────────────────────────────────
 let _lbOptIn = false;
 
@@ -1875,6 +1943,17 @@ function render(d) {
 
   // Lap table
   _checkToasts(d.laps);
+
+  // Toast: race result (fires once when Final Classification packet arrives)
+  if (d.race_result && d.race_result.recorded_at !== _lastRaceResultTs) {
+    _lastRaceResultTs = d.race_result.recorded_at;
+    const rr = d.race_result;
+    const status = RACE_STATUS[rr.result_status] || '?';
+    const msg = rr.result_status === 3
+      ? `Race finished: P${rr.position} · ${rr.points} pts${rr.fastest_lap ? ' · Fastest Lap!' : ''}`
+      : `Race ended: ${status}`;
+    showToast(msg, rr.position === 1 ? 'pb' : 'info', 6000);
+  }
 
   // Find best sector times across valid laps (for mini-best highlighting)
   const validLaps = d.laps.filter(l => !l.invalid);
@@ -2450,6 +2529,17 @@ class Handler(BaseHTTPRequestHandler):
                 out = dict(state)
                 out["track_svg"] = TRACK_SVG.get(track_name)
                 payload = json.dumps(out).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", len(payload))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        elif parsed.path == "/api/career":
+            recent = db_get_recent_races()
+            with state_lock:
+                stats = dict(state["career_stats"])
+            payload = json.dumps({"stats": stats, "recent": recent}).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", len(payload))

--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 import azure.functions as func
 from azure.cosmos import CosmosClient, PartitionKey
 from azure.cosmos.exceptions import CosmosResourceNotFoundError
+import hashlib
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
@@ -25,6 +26,7 @@ DB_NAME = "f1tracker"
 LEADERBOARD_CONTAINER = "leaderboard"
 DEBRIEF_USAGE_CONTAINER = "debrief_usage"
 DAILY_DEBRIEF_LIMIT = 10
+DAILY_IP_DEBRIEF_LIMIT = 20   # higher limit per IP to allow shared networks
 
 
 # ---------------------------------------------------------------------------
@@ -291,6 +293,22 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
             429,
         )
 
+    # ── IP-based rate limit — prevents bypass via new UUIDs ──────────────────
+    x_forwarded = req.headers.get("X-Forwarded-For", "")
+    client_ip = x_forwarded.split(",")[0].strip() if x_forwarded else req.headers.get("X-Client-IP", "unknown")
+    ip_hash = hashlib.sha256(client_ip.encode()).hexdigest()[:16]
+    ip_pk = f"ip:{ip_hash}"
+    ip_usage_id = f"ip_{ip_hash}_{today}"
+
+    try:
+        ip_doc = usage_container.read_item(item=ip_usage_id, partition_key=ip_pk)
+        ip_count = int(ip_doc.get("count", 0))
+    except CosmosResourceNotFoundError:
+        ip_count = 0
+
+    if ip_count >= DAILY_IP_DEBRIEF_LIMIT:
+        return _error("Too many debrief requests from this network today. Resets at midnight UTC.", 429)
+
     # ── Validate lap data ─────────────────────────────────────────────────────
     laps = body.get("laps", [])
     if not laps:
@@ -363,11 +381,18 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
         logger.error("Azure OpenAI error: %s", exc)
         return _error(f"AI service error: {str(exc)}", 502)
 
-    # ── Increment usage counter (TTL 90 000 s ≈ 25 h, auto-expires) ──────────
+    # ── Increment usage counters (TTL 90 000 s ≈ 25 h, auto-expires) ─────────
     usage_container.upsert_item({
         "id": usage_id,
         "player_id": player_id,
         "count": count + 1,
+        "date": today,
+        "ttl": 90000,
+    })
+    usage_container.upsert_item({
+        "id": ip_usage_id,
+        "player_id": ip_pk,
+        "count": ip_count + 1,
         "date": today,
         "ttl": 90000,
     })


### PR DESCRIPTION
## Summary

- **Career Stats tab** — new SESSION / CAREER tab bar in the main panel; Career tab shows a stat summary (Races, Wins, Podiums, Points, Fastest Laps, DNFs) and a full race results history table
- **Final Classification parsing** — listens for UDP packet ID 8 and extracts finishing position, grid position, points, best lap, and total race time for the player; results stored in a new `race_results` SQLite table
- **Fastest Lap event parsing** — listens for packet ID 3 FTLP events; flags when the player sets the fastest lap in a session
- **Race result toast** — a notification fires automatically when a race ends (e.g. "Race finished: P2 · 18 pts · Fastest Lap!")
- **IP-based rate limiting** — the Azure debrief endpoint now rate-limits by hashed IP in addition to player UUID, preventing bypass via new UUIDs
- **`/api/career` endpoint** — returns career summary stats and recent race results as JSON

## Test plan

- [ ] SESSION tab shows the existing lap table, telemetry, PBs, and past sessions as before
- [ ] CAREER tab loads without errors when clicked
- [ ] Career stat boxes show zeros on a fresh DB; numbers increment after finishing a race
- [ ] Race results table shows track, session type, grid, finish position (coloured gold/silver/bronze), points, and best lap
- [ ] FL badge appears on rows where fastest lap was set
- [ ] Race result toast appears at the end of a race session
- [ ] `f1_laps.db` gains a `race_results` table on first run (no migration errors on existing DBs)
- [ ] Debrief endpoint rejects excess requests per IP even when player UUID changes

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS