### PR TITLE
security: harden XSS, input validation, error disclosure, and response headers

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1632,7 +1632,7 @@ async function requestDebrief() {
   } catch(e) {
     section.innerHTML = `<div class="panel debrief-panel">
       <div class="panel-title">AI Debrief — Race Engineer</div>
-      <div style="color:var(--red);font-size:.8rem">Error: ${e.message}</div>
+      <div style="color:var(--red);font-size:.8rem">Error: ${esc(e.message)}</div>
     </div>`;
   } finally {
     btn.textContent = 'AI DEBRIEF';
@@ -1643,7 +1643,10 @@ async function requestDebrief() {
 function renderDebrief(data) {
   const section = document.getElementById('debrief-section');
   const paras = data.debrief.split(/\n\n+/).filter(p => p.trim());
-  const html = paras.map(p => `<p class="debrief-para">${p.replace(/\n/g,'<br>')}</p>`).join('');
+  const html = paras.map(p => {
+    const lines = p.split('\n').map(l => esc(l)).join('<br>');
+    return `<p class="debrief-para">${lines}</p>`;
+  }).join('');
   const remainingNote = data.remaining != null
     ? `<span style="color:var(--muted);font-size:.65rem">${data.remaining} debrief${data.remaining !== 1 ? 's' : ''} remaining today</span>`
     : '';
@@ -1939,9 +1942,9 @@ function render(d) {
     : `<div class="info-row"><span class="info-key">TRACK PB</span><span class="info-val" style="color:var(--muted)">No record yet</span></div>`;
   const p3 = `<div class="panel">
     <div class="panel-title">Session</div>
-    <div class="info-row"><span class="info-key">TRACK</span><span class="info-val">${d.session.track}</span></div>
-    <div class="info-row"><span class="info-key">TYPE</span><span class="info-val">${d.session.session_type}</span></div>
-    <div class="info-row"><span class="info-key">WEATHER</span><span class="info-val">${d.session.weather}</span></div>
+    <div class="info-row"><span class="info-key">TRACK</span><span class="info-val">${esc(d.session.track)}</span></div>
+    <div class="info-row"><span class="info-key">TYPE</span><span class="info-val">${esc(d.session.session_type)}</span></div>
+    <div class="info-row"><span class="info-key">WEATHER</span><span class="info-val">${esc(d.session.weather)}</span></div>
     <div class="info-row"><span class="info-key">POSITION</span><span class="info-val">${d.player_position > 0 ? 'P' + d.player_position : '—'}</span></div>
     ${pbRow}
   </div>`;
@@ -2699,6 +2702,8 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
             self.send_header("Content-Length", len(body))
+            self.send_header("X-Frame-Options", "SAMEORIGIN")
+            self.send_header("X-Content-Type-Options", "nosniff")
             self.end_headers()
             self.wfile.write(body)
 

--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -1,3 +1,5 @@
+import hashlib
+import ipaddress
 import json
 import logging
 import os
@@ -7,7 +9,6 @@ from datetime import datetime, timezone
 import azure.functions as func
 from azure.cosmos import CosmosClient, PartitionKey
 from azure.cosmos.exceptions import CosmosResourceNotFoundError
-import hashlib
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
@@ -85,16 +86,24 @@ def _handle_submit(body) -> func.HttpResponse:
     compound: str = str(body.get("compound", "")).strip()
     submitted_at: str = str(body["submitted_at"]).strip()
 
+    _VALID_COMPOUNDS = {"Soft", "Medium", "Hard", "Inter", "Wet", ""}
+
     if not player_id:
         return _error("player_id must not be empty.")
     if not display_name or len(display_name) > 32:
         return _error("display_name must be between 1 and 32 characters.")
-    if not track:
-        return _error("track must not be empty.")
-    if not session_type:
-        return _error("session_type must not be empty.")
+    if not all(c.isprintable() for c in display_name):
+        return _error("display_name contains invalid characters.")
+    if not track or len(track) > 60:
+        return _error("track must be between 1 and 60 characters.")
+    if not session_type or len(session_type) > 30:
+        return _error("session_type must be between 1 and 30 characters.")
     if not isinstance(lap_time_ms, int) or not (30_000 <= lap_time_ms <= 600_000):
         return _error("lap_time_ms must be an integer between 30000 and 600000.")
+    if len(lap_time) > 20:
+        return _error("lap_time string too long.")
+    if compound not in _VALID_COMPOUNDS:
+        return _error("Invalid compound value.")
 
     doc_id = f"{player_id}_{track}_{session_type}".replace(" ", "_")
     partition_key_value = f"{track}|{session_type}"
@@ -295,7 +304,12 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
 
     # ── IP-based rate limit — prevents bypass via new UUIDs ──────────────────
     x_forwarded = req.headers.get("X-Forwarded-For", "")
-    client_ip = x_forwarded.split(",")[0].strip() if x_forwarded else req.headers.get("X-Client-IP", "unknown")
+    raw_ip = x_forwarded.split(",")[0].strip() if x_forwarded else req.headers.get("X-Client-IP", "unknown")
+    try:
+        ipaddress.ip_address(raw_ip)
+        client_ip = raw_ip
+    except ValueError:
+        client_ip = "invalid"
     ip_hash = hashlib.sha256(client_ip.encode()).hexdigest()[:16]
     ip_pk = f"ip:{ip_hash}"
     ip_usage_id = f"ip_{ip_hash}_{today}"
@@ -313,6 +327,8 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
     laps = body.get("laps", [])
     if not laps:
         return _error("No laps provided.", 400)
+    if not isinstance(laps, list) or len(laps) > 200:
+        return _error("laps must be an array of at most 200 entries.", 400)
 
     session       = body.get("session", {})
     best_lap_ms   = body.get("best_lap_ms")
@@ -320,9 +336,13 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
     track_pb_cmp  = body.get("track_pb_compound")
 
     # ── Build prompt ──────────────────────────────────────────────────────────
-    track     = session.get("track", "Unknown")
-    sess_type = session.get("session_type", "Unknown")
-    weather   = session.get("weather", "Unknown")
+    def _clean(s: str, max_len: int = 60) -> str:
+        """Strip newlines and control characters to prevent prompt injection."""
+        return str(s).replace("\n", " ").replace("\r", " ").strip()[:max_len]
+
+    track     = _clean(session.get("track", "Unknown"))
+    sess_type = _clean(session.get("session_type", "Unknown"))
+    weather   = _clean(session.get("weather", "Unknown"))
     best_time = _ms_to_laptime(best_lap_ms)
     pb_time   = _ms_to_laptime(track_pb_ms) if track_pb_ms else "No record"
     pb_suffix = f" ({track_pb_cmp})" if track_pb_cmp else ""
@@ -379,7 +399,7 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
         text = result["choices"][0]["message"]["content"].strip()
     except Exception as exc:
         logger.error("Azure OpenAI error: %s", exc)
-        return _error(f"AI service error: {str(exc)}", 502)
+        return _error("AI service temporarily unavailable. Please try again.", 502)
 
     # ── Increment usage counters (TTL 90 000 s ≈ 25 h, auto-expires) ─────────
     usage_container.upsert_item({


### PR DESCRIPTION
## Summary

Security hardening pass across both the local dashboard and the Azure Functions backend, based on a full audit of the codebase.

### `F1_lap_tracker.py`
- **XSS — debrief error handler**: `e.message` now passed through `esc()` before insertion into `innerHTML`
- **XSS — AI debrief text**: debrief response is escaped line-by-line before `<br>` tags are inserted — a crafted server response can no longer inject and execute HTML/JS
- **XSS — session info panel**: `track`, `session_type`, and `weather` values now wrapped in `esc()` in the render template
- **Security headers**: `X-Frame-Options: SAMEORIGIN` and `X-Content-Type-Options: nosniff` added to the main HTML response to block clickjacking and MIME sniffing

### `leaderboard_api/function_app.py`
- **IP validation**: `X-Forwarded-For` value is now validated as a real IP address via Python's `ipaddress` module before being hashed for rate limiting — malformed/spoofed headers fall back to `"invalid"`
- **DoS protection**: debrief endpoint now caps the `laps` array at 200 entries before building the AI prompt
- **Prompt injection**: track, session type, and weather fields have newlines and carriage returns stripped via a `_clean()` helper before being inserted into the AI prompt
- **Input validation (lb-submit)**: added field length limits for `lap_time` and `track`/`session_type`, a compound whitelist (`Soft/Medium/Hard/Inter/Wet`), and a printable-characters check on `display_name`
- **Error disclosure**: raw Azure OpenAI exception details are no longer returned to the client — replaced with a generic `"AI service temporarily unavailable"` 502 response; full error still logged server-side

## Test plan

- [ ] AI debrief still generates and displays correctly
- [ ] Debrief error state shows a sanitized message (not raw exception text)
- [ ] Session info panel (track, type, weather) renders correctly
- [ ] Leaderboard submit rejects invalid compound values
- [ ] Leaderboard submit rejects display names with non-printable characters
- [ ] Debrief endpoint returns 400 if more than 200 laps are submitted
- [ ] Azure Function returns generic 502 on OpenAI error (check logs for full detail)

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS