### PR TITLE
fix: career tab duplicate entries + security hardening

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -98,6 +98,7 @@ state = {
     "career_stats": {"races":0,"wins":0,"podiums":0,"points":0,"fastest_laps":0,"dnfs":0},
     "race_result": None,               # populated when Final Classification packet (ID 8) arrives
     "player_fastest_lap": False,       # set True when FTLP event fires for the player
+    "race_result_saved_sid": None,     # session ID for which race result was already saved
 }
 
 TRACK_IDS = {
@@ -766,11 +767,23 @@ def parse_final_classification_packet(data, player_idx):
         best_lap_ms   = struct.unpack_from("<I", data, car_base + 6)[0]
         total_time_s  = struct.unpack_from("<d", data, car_base + 10)[0]
         best_lap_str  = ms_to_laptime(best_lap_ms) if best_lap_ms > 0 else "—"
+
+        # Only save when the race is actually over — status must be Finished,
+        # DNF, DSQ, N/C, or Retired. Ignore Invalid/Inactive/Active packets
+        # which the game sends during formation lap and mid-race.
+        FINAL_STATUSES = {3, 4, 5, 6, 7}  # Finished, DNF, DSQ, N/C, Retired
+        if result_status not in FINAL_STATUSES:
+            return
+
         with state_lock:
-            fastest  = state["player_fastest_lap"]
-            state["player_fastest_lap"] = False
-            sid      = state["current_session_id"]
-            track    = state["session"]["track"]
+            sid = state["current_session_id"]
+            # Guard against the game re-sending this packet on the results screen
+            if state["race_result_saved_sid"] == sid:
+                return
+            fastest   = state["player_fastest_lap"]
+            state["player_fastest_lap"]    = False
+            state["race_result_saved_sid"] = sid
+            track     = state["session"]["track"]
             sess_type = state["session"]["session_type"]
             state["race_result"] = {
                 "position": position,


### PR DESCRIPTION
## Summary

### Bug fix — Career tab duplicate race results
- **Root cause 1**: The game sends the Final Classification packet (ID 8) repeatedly on the results screen, causing a DB insert on every packet. Fixed with a per-session guard (`race_result_saved_sid`) so the result is written exactly once.
- **Root cause 2**: The packet is also sent mid-race and during formation lap when `result_status` is `0` (Invalid), `1` (Inactive), or `2` (Active). Fixed by only saving when status is a terminal state: `Finished`, `DNF`, `DSQ`, `N/C`, or `Retired`.

### Security hardening (from audit)
- XSS: `e.message`, AI debrief text, and session info fields (track/type/weather) now HTML-escaped before `innerHTML` insertion
- Security headers: `X-Frame-Options: SAMEORIGIN` and `X-Content-Type-Options: nosniff` added to HTML response
- Azure Function: `X-Forwarded-For` validated as real IP via `ipaddress` module before hashing
- Azure Function: debrief endpoint caps `laps` array at 200 entries
- Azure Function: `_clean()` helper strips newlines from session fields before AI prompt construction
- Azure Function: `lb-submit` enforces field length limits, compound whitelist, and printable-char check on display names
- Azure Function: generic 502 returned on Azure OpenAI errors instead of raw exception details

## Test plan
- [ ] Run one full race — Career tab should show exactly 1 result with correct position, grid, and points
- [ ] Stay on results screen for 30+ seconds — no duplicate entries appear
- [ ] Career stats (wins, podiums, points) update correctly after the race
- [ ] Race result toast fires once at the end of the race

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS