### PR TITLE
Move leaderboard to its own tab; fix career recording

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -781,21 +781,26 @@ def parse_final_classification_packet(data, player_idx):
         RACE_SESSION_TYPES = {"Race", "Race 2", "Race 3"}
 
         with state_lock:
-            sid = state["current_session_id"]
-            # Guard against the game re-sending this packet on the results screen
-            if state["race_result_saved_sid"] == sid:
-                return
-            fastest   = state["player_fastest_lap"]
-            state["player_fastest_lap"]    = False
-            state["race_result_saved_sid"] = sid
+            sid       = state["current_session_id"]
             track     = state["session"]["track"]
             sess_type = state["session"]["session_type"]
 
+        print(f"[Final Classification] status={result_status} pos={position} "
+              f"sess='{sess_type}' track='{track}' sid={sid}")
+
         # Only record career results for race sessions
         if sess_type not in RACE_SESSION_TYPES:
+            print(f"[Final Classification] skipped — session type '{sess_type}' not a race")
             return
 
         with state_lock:
+            # Guard against the game re-sending this packet on the results screen
+            if sid is not None and state["race_result_saved_sid"] == sid:
+                print(f"[Final Classification] skipped — already saved for session {sid}")
+                return
+            fastest = state["player_fastest_lap"]
+            state["player_fastest_lap"]    = False
+            state["race_result_saved_sid"] = sid
             state["race_result"] = {
                 "position": position,
                 "grid_pos": grid_pos,
@@ -1311,7 +1316,7 @@ tr.comp-b-row td { background:rgba(247,164,76,.07); }
 tr.lb-player { background: rgba(0,214,143,.08); }
 tr.lb-player td { color: var(--green); }
 td.lb-rank { color: var(--muted); font-size: .7rem; width: 32px; }
-.sidebar .lb-wrap .lap-table-wrap { max-height: 280px; overflow-y: auto; }
+#tab-leaderboard .lb-wrap .lap-table-wrap { max-height: 600px; overflow-y: auto; }
 td.lb-rank.top3 { color: var(--gold); font-family: 'Orbitron', sans-serif; font-weight: 700; }
 
 /* AI Debrief panel */
@@ -1434,12 +1439,12 @@ transition: border-color .2s, color .2s;
         <button class="map-mode-btn" id="lap-nav-live" onclick="lapNavLive()" style="margin-left:4px;border-color:var(--green);color:var(--green);">LIVE</button>
       </div>
     </div>
-    <div id="lb-section"></div>
   </aside>
   <div class="main-col">
     <div class="tab-bar">
       <button class="tab active" id="tab-btn-session" onclick="switchTab('session')">SESSION</button>
       <button class="tab" id="tab-btn-career" onclick="switchTab('career')">CAREER</button>
+      <button class="tab" id="tab-btn-leaderboard" onclick="switchTab('leaderboard')">LEADERBOARD</button>
     </div>
     <div id="tab-session">
     <div id="comp-bar">
@@ -1475,18 +1480,23 @@ transition: border-color .2s, color .2s;
     <div id="tab-career" style="display:none">
       <div id="career-section"></div>
     </div>
+    <div id="tab-leaderboard" style="display:none">
+      <div id="lb-section"></div>
+    </div>
   </div>
 </div>
 
 <script>
 // ── Tab system ────────────────────────────────────────────────────────────────
 function switchTab(name) {
-  document.getElementById('tab-session').style.display = name === 'session' ? '' : 'none';
-  document.getElementById('tab-career').style.display  = name === 'career'  ? '' : 'none';
+  document.getElementById('tab-session').style.display     = name === 'session'     ? '' : 'none';
+  document.getElementById('tab-career').style.display      = name === 'career'      ? '' : 'none';
+  document.getElementById('tab-leaderboard').style.display = name === 'leaderboard' ? '' : 'none';
   document.querySelectorAll('.tab').forEach(t =>
     t.classList.toggle('active', t.id === `tab-btn-${name}`)
   );
   if (name === 'career') loadCareer();
+  if (name === 'leaderboard') fetchLeaderboard();
 }
 
 // ── Career stats ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Leaderboard tab** — moved the Community Leaderboard out of the sidebar (where the track map was pushing it off-screen) and into a dedicated **LEADERBOARD** tab alongside SESSION and CAREER. The tab auto-fetches on click and has 600px of scroll height.
- **Career recording fix** — two bugs patched:
  1. The session-type guard (`sess_type not in RACE_SESSION_TYPES`) now runs *before* the per-session duplicate guard is stamped. Previously a non-race Final Classification packet could permanently block the race result from saving within the same session.
  2. `None == None` false-positive in the duplicate guard — if no session packet had arrived yet, the guard would fire incorrectly.
- **Terminal logging** — Final Classification packets now print status, position, session type, track, and session ID to the terminal for easier debugging.

## Test plan

- [ ] Start app and confirm three tabs appear: SESSION, CAREER, LEADERBOARD
- [ ] Click LEADERBOARD tab — leaderboard loads (or shows "Waiting for session data…" placeholder)
- [ ] Track map in sidebar no longer hides any leaderboard content
- [ ] Complete a race session — terminal should show `[Final Classification] status=3 pos=X sess='Race' track='...' sid=N`
- [ ] Switch to CAREER tab after the race — result should appear

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS
EOF
)