### PR TITLE
Add telemetry data to AI debrief

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -640,6 +640,26 @@ def parse_lap_data_packet(data, player_idx):
                     state["track_outline"] = saved_trace
                 state["lap_trace"] = []
 
+        # Compute aggregate telemetry stats from the trace and store in lap record
+        if saved_trace:
+            n = len(saved_trace)
+            max_spd  = max(p["speed"]              for p in saved_trace)
+            avg_spd  = sum(p["speed"]              for p in saved_trace) / n
+            avg_thr  = sum(p["throttle"]           for p in saved_trace) / n * 100
+            ft_pct   = sum(1 for p in saved_trace if p["throttle"] >= 0.95) / n * 100
+            avg_brk  = sum(p["brake"]              for p in saved_trace) / n * 100
+            hb_pct   = sum(1 for p in saved_trace if p["brake"] >= 0.5)  / n * 100
+            max_g    = max(abs(p.get("gLat", 0))   for p in saved_trace)
+            lap_record["telem"] = {
+                "max_speed":         round(max_spd),
+                "avg_speed":         round(avg_spd),
+                "avg_throttle":      round(avg_thr),
+                "full_throttle_pct": round(ft_pct),
+                "avg_brake":         round(avg_brk),
+                "heavy_brake_pct":   round(hb_pct),
+                "max_g_lat":         round(max_g, 2),
+            }
+
         if save_session_id is not None:
             db_save_lap(save_session_id, lap_record, trace=saved_trace)
         if save_pb_data is not None:

--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -358,17 +358,50 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
             f"{lap.get('s3', '—'):>9} | {valid}"
         )
 
+    # Build telemetry table if any laps have telem data
+    telem_laps = [lap for lap in laps if lap.get("telem")]
+    telem_section = ""
+    if telem_laps:
+        th = "Lap | MaxSpd | AvgSpd | AvgThr% | FullThr% | AvgBrk% | HvyBrk% | MaxGLat"
+        trows = []
+        for lap in telem_laps:
+            t = lap["telem"]
+            trows.append(
+                f"Lap {lap.get('lap_num', '?'):>3} | "
+                f"{t.get('max_speed', '—'):>6} | "
+                f"{t.get('avg_speed', '—'):>6} | "
+                f"{t.get('avg_throttle', '—'):>7} | "
+                f"{t.get('full_throttle_pct', '—'):>8} | "
+                f"{t.get('avg_brake', '—'):>7} | "
+                f"{t.get('heavy_brake_pct', '—'):>7} | "
+                f"{t.get('max_g_lat', '—'):>7}"
+            )
+        telem_section = (
+            "\n\nTelemetry data (speed km/h, throttle/brake as %, G-force):\n"
+            f"{th}\n" + "\n".join(trows)
+        )
+
+    has_telem = bool(telem_laps)
+    telem_instruction = (
+        " Where telemetry data is available, reference it specifically — "
+        "comment on top speed, throttle application (full-throttle %), "
+        "braking commitment (heavy-brake %), and peak lateral G as indicators of "
+        "driving style and corner technique. Cross-reference with sector times to "
+        "pinpoint where time is being lost."
+        if has_telem else ""
+    )
+
     prompt = (
         "You are a Formula 1 race engineer giving a post-session debrief to a sim racing driver.\n"
-        "Analyse the lap data below and give a concise, insightful debrief (3–5 short paragraphs).\n"
+        "Analyse the lap and telemetry data below and give a concise, insightful debrief (3–5 short paragraphs).\n"
         "Cover: pace consistency, sector weaknesses, tyre compound performance, best lap analysis, "
-        "and one actionable recommendation for the next session.\n"
+        f"and one actionable recommendation for the next session.{telem_instruction}\n"
         "Use F1 engineering language. Be direct. Interpret the numbers — do not just repeat them.\n\n"
         f"Session: {track} — {sess_type} — {weather}\n"
         f"Session Best: {best_time}\n"
         f"Track PB: {pb_time}{pb_suffix}\n"
         f"Total laps: {len(laps)}\n\n"
-        f"Lap data:\n{header}\n" + "\n".join(rows)
+        f"Lap data:\n{header}\n" + "\n".join(rows) + telem_section
     )
 
     # ── Call Azure OpenAI ─────────────────────────────────────────────────────
@@ -382,7 +415,7 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
     aoai_url     = f"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version=2024-02-01"
     aoai_payload = json.dumps({
         "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": 600,
+        "max_tokens": 800,
         "temperature": 0.7,
     }).encode()
 


### PR DESCRIPTION
## Summary

- **Per-lap telemetry stats** — when each lap completes, aggregate stats are computed from the motion trace and stored in the lap record: max/avg speed (km/h), avg throttle %, full-throttle %, avg brake %, heavy-brake %, and peak lateral G
- **Richer AI prompt** — the Azure Function now includes a second telemetry table alongside the lap times table, and instructs the AI to cross-reference speed, throttle commitment, braking style, and lateral G against sector times to give corner-specific feedback
- **`max_tokens` raised** from 600 → 800 to give the AI room for the more detailed analysis

The debrief can now say things like: *"Your full-throttle percentage dropped from 41% on Lap 3 to 29% on Lap 7, coinciding with a 0.4s Sector 2 regression — you're likely backing off early through the fast chicane."*

## Test plan

- [ ] Drive a session with telemetry enabled (motion packets flowing)
- [ ] Request an AI Debrief — response should reference top speed, throttle %, braking %, and/or G-force in addition to sector times
- [ ] Sessions without trace data (e.g. older laps loaded from DB) still produce a valid debrief using lap times only
- [ ] Redeploy the Azure Function for the prompt changes to take effect

## Notes

- The Azure Function **must be redeployed** for the updated prompt to go live
- Telemetry stats are computed from the live motion trace — they populate as new laps are completed; laps recorded before this update won't have `telem` data

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS