### PR TITLE
Fix seed_leaderboard.py DB path

### DIFF
--- a/seed_leaderboard.py
+++ b/seed_leaderboard.py
@@ -29,7 +29,7 @@ LEADERBOARD_URL = os.environ.get(
 if LEADERBOARD_URL.endswith("/api"):
     LEADERBOARD_URL = LEADERBOARD_URL[:-4]
 
-DB_PATH = os.path.join(os.path.dirname(__file__), "f1_telemetry.db")
+DB_PATH = os.path.join(os.path.dirname(__file__), "f1_laps.db")
 
 PLACEHOLDER_PLAYER_ID   = "test_placeholder_seed"
 PLACEHOLDER_DISPLAY     = "Test Driver"


### PR DESCRIPTION
## Summary

- Fix wrong DB filename in `seed_leaderboard.py`: was `f1_telemetry.db`, should be `f1_laps.db` (matching the path used by the main app)

## Test plan

- [ ] Merge and `git pull`
- [ ] Run `python seed_leaderboard.py` — should connect successfully and post placeholder times for each track in your personal bests

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS