### PR TITLE
Split leaderboard into two dropdowns; fix seed script urllib + use real PB times

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1582,13 +1582,17 @@ backdrop-filter: blur(4px);
       </div>
     </div>
     <div id="tab-leaderboard" style="display:none">
-      <div class="panel" style="margin-bottom:10px;padding:10px 14px;display:flex;align-items:center;gap:12px;flex-wrap:wrap;">
+      <div class="panel" style="margin-bottom:10px;padding:10px 14px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;">
         <select id="lb-track-select" onchange="onLbTrackChange()"
-          style="background:var(--bg2);color:var(--fg);border:1px solid var(--border);border-radius:4px;padding:5px 8px;font-family:inherit;font-size:.78rem;min-width:220px;cursor:pointer">
-          <option value="">— Select Track / Session Type —</option>
+          style="background:var(--bg2);color:var(--fg);border:1px solid var(--border);border-radius:4px;padding:5px 8px;font-family:inherit;font-size:.78rem;min-width:180px;cursor:pointer">
+          <option value="">— Track —</option>
+        </select>
+        <select id="lb-sesstype-select" onchange="onLbSessTypeChange()"
+          style="background:var(--bg2);color:var(--fg);border:1px solid var(--border);border-radius:4px;padding:5px 8px;font-family:inherit;font-size:.78rem;min-width:130px;cursor:pointer">
+          <option value="">— Session Type —</option>
         </select>
         <div style="display:flex;gap:4px;margin-left:auto;">
-          <button id="lb-btn-mine" class="btn" style="opacity:1" onclick="switchLbView('mine')">MY TIMES</button>
+          <button id="lb-btn-mine" class="btn" onclick="switchLbView('mine')">MY TIMES</button>
           <button id="lb-btn-community" class="btn" onclick="switchLbView('community')">COMMUNITY</button>
         </div>
       </div>
@@ -1712,45 +1716,67 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 // ── Leaderboard tab state ─────────────────────────────────────────────────────
-let _lbView = 'mine';    // 'mine' | 'community'
-let _lbPbs  = [];        // all personal bests from DB
-let _lbTrackKey = '';    // "Track Name||Session Type"
+let _lbView        = 'mine';   // 'mine' | 'community'
+let _lbPbs         = [];       // all personal bests from DB
+let _lbTrack       = '';       // selected track name
+let _lbSessionType = '';       // selected session type
 
 async function fetchLeaderboard() {
-  // Reload PBs and rebuild the track dropdown
   try {
     const r = await fetch('/api/pbs');
     _lbPbs = await r.json();
   } catch(e) { _lbPbs = []; }
 
-  // Sort by most recently set first so the dropdown defaults to your latest track
+  // Most recently driven first
   _lbPbs.sort((a, b) => (b.set_at || '').localeCompare(a.set_at || ''));
 
-  const select = document.getElementById('lb-track-select');
-  const seen = new Set();
-  select.innerHTML = '<option value="">— Select Track / Session Type —</option>';
+  // Build track dropdown (unique tracks)
+  const trackSelect = document.getElementById('lb-track-select');
+  const tracksSeen = new Set();
+  trackSelect.innerHTML = '<option value="">— Track —</option>';
   for (const pb of _lbPbs) {
-    const key = `${pb.track}||${pb.session_type}`;
-    if (!seen.has(key)) {
-      seen.add(key);
+    if (!tracksSeen.has(pb.track)) {
+      tracksSeen.add(pb.track);
       const opt = document.createElement('option');
-      opt.value = key;
-      opt.textContent = `${pb.track} — ${pb.session_type || 'Unknown'}`;
-      select.appendChild(opt);
+      opt.value = pb.track;
+      opt.textContent = pb.track;
+      trackSelect.appendChild(opt);
     }
   }
 
-  // Pre-select: keep current selection if still valid, otherwise pick first
-  if (_lbTrackKey && seen.has(_lbTrackKey)) {
-    select.value = _lbTrackKey;
+  // Keep existing selection or default to first
+  if (_lbTrack && tracksSeen.has(_lbTrack)) {
+    trackSelect.value = _lbTrack;
   } else if (_lbPbs.length) {
-    _lbTrackKey = `${_lbPbs[0].track}||${_lbPbs[0].session_type}`;
-    select.value = _lbTrackKey;
+    _lbTrack = _lbPbs[0].track;
+    trackSelect.value = _lbTrack;
   }
 
-  // Set active button styles
+  _buildSessTypeDropdown();
   _setLbBtnActive(_lbView);
   renderLbView();
+}
+
+function _buildSessTypeDropdown() {
+  const sessSelect = document.getElementById('lb-sesstype-select');
+  const types = [...new Set(
+    _lbPbs.filter(pb => pb.track === _lbTrack).map(pb => pb.session_type)
+  )];
+  sessSelect.innerHTML = '<option value="">— Session Type —</option>';
+  for (const st of types) {
+    const opt = document.createElement('option');
+    opt.value = st;
+    opt.textContent = st || 'Unknown';
+    sessSelect.appendChild(opt);
+  }
+  if (_lbSessionType && types.includes(_lbSessionType)) {
+    sessSelect.value = _lbSessionType;
+  } else if (types.length) {
+    _lbSessionType = types[0];
+    sessSelect.value = _lbSessionType;
+  } else {
+    _lbSessionType = '';
+  }
 }
 
 function _setLbBtnActive(view) {
@@ -1759,7 +1785,14 @@ function _setLbBtnActive(view) {
 }
 
 function onLbTrackChange() {
-  _lbTrackKey = document.getElementById('lb-track-select').value;
+  _lbTrack = document.getElementById('lb-track-select').value;
+  _lbSessionType = '';
+  _buildSessTypeDropdown();
+  renderLbView();
+}
+
+function onLbSessTypeChange() {
+  _lbSessionType = document.getElementById('lb-sesstype-select').value;
   renderLbView();
 }
 
@@ -1774,23 +1807,17 @@ function renderLbView() {
   else renderCommunity();
 }
 
-function _parseLbKey(key) {
-  const idx = key.indexOf('||');
-  return { track: key.slice(0, idx), session_type: key.slice(idx + 2) };
-}
-
 function renderMyTimes() {
   const el = document.getElementById('lb-section');
-  if (!_lbTrackKey) {
-    el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">Select a track above to see your times.</p></div>`;
+  if (!_lbTrack || !_lbSessionType) {
+    el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">Select a track and session type above.</p></div>`;
     return;
   }
-  const { track, session_type } = _parseLbKey(_lbTrackKey);
-  const hits = _lbPbs.filter(p => p.track === track && p.session_type === session_type);
+  const hits = _lbPbs.filter(p => p.track === _lbTrack && p.session_type === _lbSessionType);
   if (!hits.length) {
     el.innerHTML = `<div class="panel lb-wrap">
-      <div class="panel-title">My Times — ${esc(track)} · ${esc(session_type)}</div>
-      <p style="color:var(--muted);font-size:.75rem;margin:8px 0">No times recorded yet for this track.</p>
+      <div class="panel-title">My Times — ${esc(_lbTrack)} · ${esc(_lbSessionType)}</div>
+      <p style="color:var(--muted);font-size:.75rem;margin:8px 0">No times recorded yet for this combination.</p>
     </div>`;
     return;
   }
@@ -1799,16 +1826,15 @@ function renderMyTimes() {
     const setAt = pb.set_at ? pb.set_at.replace('T', ' ').substring(0, 16) : '—';
     rows += `<tr>
       <td class="lap-time" style="color:var(--purple)">${esc(pb.lap_time)}</td>
-      <td style="color:var(--muted);font-size:.72rem">${esc(pb.session_type || '—')}</td>
       <td>${compoundPill(pb.compound)}</td>
       <td style="color:var(--muted);font-size:.72rem">${setAt}</td>
     </tr>`;
   }
   el.innerHTML = `<div class="panel lb-wrap">
-    <div class="panel-title">My Times — ${esc(track)} · ${esc(session_type)}</div>
+    <div class="panel-title">My Times — ${esc(_lbTrack)} · ${esc(_lbSessionType)}</div>
     <div class="lap-table-wrap">
       <table>
-        <thead><tr><th>TIME</th><th>TYPE</th><th>TYRE</th><th>SET</th></tr></thead>
+        <thead><tr><th>TIME</th><th>TYRE</th><th>SET</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>
@@ -1817,20 +1843,19 @@ function renderMyTimes() {
 
 async function renderCommunity() {
   const el = document.getElementById('lb-section');
-  if (!_lbTrackKey) {
-    el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">Select a track above to see the community leaderboard.</p></div>`;
+  if (!_lbTrack || !_lbSessionType) {
+    el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">Select a track and session type above.</p></div>`;
     return;
   }
-  const { track, session_type } = _parseLbKey(_lbTrackKey);
   el.innerHTML = `<div class="panel lb-wrap">
-    <div class="panel-title">Community — ${esc(track)} · ${esc(session_type)}</div>
+    <div class="panel-title">Community — ${esc(_lbTrack)} · ${esc(_lbSessionType)}</div>
     <p style="color:var(--muted);font-size:.75rem;margin:8px 0">Loading…</p>
   </div>`;
   try {
     await fetch('/api/lb-refresh', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ track, session_type }),
+      body: JSON.stringify({ track: _lbTrack, session_type: _lbSessionType }),
     });
     await new Promise(r => setTimeout(r, 1800));
     const r = await fetch('/api/leaderboard');
@@ -1841,10 +1866,9 @@ async function renderCommunity() {
 
 function renderLeaderboard(d) {
   const el = document.getElementById('lb-section');
-  const { track, session_type } = _lbTrackKey ? _parseLbKey(_lbTrackKey) : { track: '', session_type: '' };
   if (!d || !d.entries || d.entries.length === 0) {
     el.innerHTML = `<div class="panel lb-wrap">
-      <div class="panel-title">Community — ${esc(track)} · ${esc(session_type)}</div>
+      <div class="panel-title">Community — ${esc(_lbTrack)} · ${esc(_lbSessionType)}</div>
       <p style="color:var(--muted);font-size:.75rem;margin:8px 0">No community times posted for this track yet.</p>
     </div>`;
     return;
@@ -1864,7 +1888,7 @@ function renderLeaderboard(d) {
     : '';
   el.innerHTML = `<div class="panel lb-wrap">
     <div class="panel-title" style="display:flex;justify-content:space-between;align-items:center;">
-      <span>Community — ${esc(d.track || track)} · ${esc(d.session_type || session_type)}</span>
+      <span>Community — ${esc(d.track || _lbTrack)} · ${esc(d.session_type || _lbSessionType)}</span>
       ${rankNote}
     </div>
     <div class="lap-table-wrap">

--- a/seed_leaderboard.py
+++ b/seed_leaderboard.py
@@ -1,24 +1,23 @@
 """
-seed_leaderboard.py — Post 5-minute placeholder times to the community leaderboard
-for every track/session-type combo in your local personal_bests DB.
+seed_leaderboard.py — Submit your local personal bests to the community leaderboard.
+
+Useful if you set times before the leaderboard feature was configured, or if you
+want to re-sync your historical bests after a fresh install.
 
 Usage:
     python seed_leaderboard.py
 
-The placeholder driver is identified as "TestDriver" with player_id
-"test_placeholder_seed". Because the leaderboard only saves a time if it is
-FASTER than an existing entry for that player_id, running this twice is safe.
-Real driver entries (with your actual player_id) will never be affected.
+The leaderboard only updates an entry if the submitted time is FASTER than the
+existing one, so running this multiple times is safe.
 
-Set F1_LEADERBOARD_URL env var if you host your own instance, otherwise the
-default shared Pitwall IQ backend is used.
+Set F1_LEADERBOARD_URL env var if you host your own instance.
 """
 
 import json
 import os
 import sqlite3
-import urllib.request as urllib
 from datetime import datetime, timezone
+from urllib.request import urlopen, Request as URLRequest
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
@@ -31,62 +30,80 @@ if LEADERBOARD_URL.endswith("/api"):
 
 DB_PATH = os.path.join(os.path.dirname(__file__), "f1_laps.db")
 
-PLACEHOLDER_PLAYER_ID   = "test_placeholder_seed"
-PLACEHOLDER_DISPLAY     = "Test Driver"
-PLACEHOLDER_LAP_MS      = 5 * 60 * 1000   # 5:00.000
-PLACEHOLDER_LAP_TIME    = "5:00.000"
-PLACEHOLDER_COMPOUND    = ""
+
+def get_config():
+    """Read player_id and display_name from the app's config table."""
+    con = sqlite3.connect(DB_PATH)
+    def _get(key, default):
+        row = con.execute("SELECT value FROM config WHERE key=?", (key,)).fetchone()
+        return row[0] if row else default
+    player_id    = _get("player_id", None)
+    display_name = _get("display_name", "Anonymous")
+    con.close()
+    return player_id, display_name
 
 
-def get_all_track_combos():
-    """Return all unique (track, session_type) pairs from personal_bests."""
+def get_all_pbs():
+    """Return all personal bests from the DB."""
     con = sqlite3.connect(DB_PATH)
     rows = con.execute(
-        "SELECT DISTINCT track, session_type FROM personal_bests ORDER BY track"
+        "SELECT track, session_type, lap_time_ms, lap_time, compound "
+        "FROM personal_bests ORDER BY track, session_type"
     ).fetchall()
     con.close()
     return rows
 
 
-def submit_time(track: str, session_type: str) -> dict:
+def submit_time(player_id, display_name, track, session_type,
+                lap_time_ms, lap_time, compound) -> dict:
     payload = json.dumps({
-        "player_id":    PLACEHOLDER_PLAYER_ID,
-        "display_name": PLACEHOLDER_DISPLAY,
+        "player_id":    player_id,
+        "display_name": display_name,
         "track":        track,
         "session_type": session_type,
-        "lap_time_ms":  PLACEHOLDER_LAP_MS,
-        "lap_time":     PLACEHOLDER_LAP_TIME,
-        "compound":     PLACEHOLDER_COMPOUND,
+        "lap_time_ms":  int(lap_time_ms),
+        "lap_time":     lap_time,
+        "compound":     compound or "",
         "submitted_at": datetime.now(timezone.utc).isoformat(),
     }).encode()
 
-    req = urllib.Request(
+    req = URLRequest(
         f"{LEADERBOARD_URL}/api/lb-submit",
         data=payload,
         headers={"Content-Type": "application/json"},
         method="POST",
     )
     try:
-        with urllib.urlopen(req, timeout=10) as resp:
+        with urlopen(req, timeout=10) as resp:
             return json.loads(resp.read())
     except Exception as exc:
         return {"ok": False, "error": str(exc)}
 
 
 def main():
-    combos = get_all_track_combos()
-    if not combos:
-        print("No personal bests found in the DB — nothing to seed.")
+    player_id, display_name = get_config()
+    if not player_id:
+        print("No player_id found — start the app at least once first.")
         return
 
-    print(f"Seeding {len(combos)} track/session combo(s) with a {PLACEHOLDER_LAP_TIME} placeholder…\n")
-    for track, session_type in combos:
-        result = submit_time(track, session_type)
-        status = "ok" if result.get("ok") else f"FAILED: {result.get('error', '?')}"
-        print(f"  {track:30s} | {session_type:15s} → {status}")
+    pbs = get_all_pbs()
+    if not pbs:
+        print("No personal bests found in the DB — nothing to submit.")
+        return
 
-    print("\nDone. Community leaderboard entries with 5:00.000 placeholder times are now live.")
-    print("Any real driver time will rank above these since 5 minutes is very slow.")
+    print(f"Submitting {len(pbs)} personal best(s) as '{display_name}'...\n")
+    for track, session_type, lap_time_ms, lap_time, compound in pbs:
+        result = submit_time(player_id, display_name, track, session_type,
+                             lap_time_ms, lap_time, compound)
+        if result.get("ok"):
+            rank = result.get("rank", "?")
+            updated = result.get("updated", False)
+            note = f"rank #{rank}" + (" — new best!" if updated else " (no improvement)")
+        else:
+            note = f"FAILED: {result.get('error', '?')}"
+        print(f"  {track:30s} | {session_type:15s} | {lap_time:12s} → {note}")
+
+    print("\nDone.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Two dropdowns** — Track and Session Type are now separate selects. Changing the track auto-filters the Session Type dropdown to only show types you've driven at that track.
- **Seed script uses real times** — `seed_leaderboard.py` now reads your actual `lap_time_ms`, `lap_time`, and `compound` from `personal_bests` and submits them under your real `player_id` and display name. Reports the rank you achieved for each entry.
- **Fix urllib import in seed script** — the aliased `import urllib.request as urllib` broke HTTPS handler registration. Changed to `from urllib.request import urlopen, Request` (same pattern the main app uses).

## Test plan

- [ ] Merge and `git pull`
- [ ] Open Leaderboard tab — two dropdowns visible (Track, Session Type)
- [ ] Selecting a track filters session type options to only what you've driven there
- [ ] MY TIMES and COMMUNITY views both respond to both dropdowns
- [ ] Run `python seed_leaderboard.py` — submits your real PB times, prints rank for each track

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS