### PR TITLE
Route leaderboard seeding through local app server to fix HTTPS errors

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -911,7 +911,36 @@ def _lb_post(payload):
             pass
     threading.Thread(target=_run, daemon=True).start()
 
-def _lb_refresh(track_override=None, session_type_override=None):
+def _lb_seed_all():
+    """Submit every personal best to the community leaderboard via _lb_post."""
+    if not LEADERBOARD_URL:
+        return 0
+    with state_lock:
+        player_id    = state.get("player_id") or ""
+        display_name = state.get("display_name") or "Anonymous"
+    if not player_id:
+        return 0
+    pbs = db_get_all_pbs()
+    import datetime as _dt
+    now = _dt.datetime.now(_dt.timezone.utc).isoformat()
+    count = 0
+    for pb in pbs:
+        if not pb.get("lap_time_ms"):
+            continue
+        _lb_post({
+            "player_id":    player_id,
+            "display_name": display_name,
+            "track":        pb["track"],
+            "session_type": pb["session_type"],
+            "lap_time_ms":  int(pb["lap_time_ms"]),
+            "lap_time":     pb["lap_time"],
+            "compound":     pb.get("compound") or "",
+            "submitted_at": now,
+        })
+        count += 1
+    return count
+
+
     """Fetch leaderboard for the given (or current) track from Azure and cache in state."""
     if not LEADERBOARD_URL:
         return
@@ -1594,6 +1623,7 @@ backdrop-filter: blur(4px);
         <div style="display:flex;gap:4px;margin-left:auto;">
           <button id="lb-btn-mine" class="btn" onclick="switchLbView('mine')">MY TIMES</button>
           <button id="lb-btn-community" class="btn" onclick="switchLbView('community')">COMMUNITY</button>
+          <button id="lb-btn-sync" class="btn" onclick="syncMyTimes()" title="Submit all your personal bests to the community leaderboard" style="display:none">SYNC MY TIMES</button>
         </div>
       </div>
       <div id="lb-section"></div>
@@ -1678,6 +1708,7 @@ async function initLB() {
     if (!c.enabled) return;
     document.getElementById('lb-controls').style.display = 'flex';
     document.getElementById('lb-name').value = c.display_name || '';
+    document.getElementById('lb-btn-sync').style.display = 'inline-block';
     _lbOptIn = c.opt_in;
     _updateToggle();
     fetchLeaderboard();
@@ -1898,6 +1929,22 @@ function renderLeaderboard(d) {
       </table>
     </div>
   </div>`;
+}
+
+async function syncMyTimes() {
+  const btn = document.getElementById('lb-btn-sync');
+  btn.textContent = 'SYNCING…';
+  btn.disabled = true;
+  try {
+    const r = await fetch('/api/lb-seed', { method: 'POST' });
+    const d = await r.json();
+    btn.textContent = `SYNCED ${d.submitted}`;
+    setTimeout(() => { btn.textContent = 'SYNC MY TIMES'; btn.disabled = false; }, 3000);
+    if (_lbView === 'community') renderCommunity();
+  } catch(e) {
+    btn.textContent = 'SYNC MY TIMES';
+    btn.disabled = false;
+  }
 }
 
 // ── AI Debrief ────────────────────────────────────────────────────────────────
@@ -3098,6 +3145,13 @@ class Handler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", "application/json")
             self.end_headers()
             self.wfile.write(b'{"ok":true}')
+        elif parsed.path == "/api/lb-seed":
+            count = _lb_seed_all()
+            payload = json.dumps({"ok": True, "submitted": count}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(payload)
         elif parsed.path == "/api/clear":
             old_session_id = None
             with state_lock:

--- a/seed_leaderboard.py
+++ b/seed_leaderboard.py
@@ -1,109 +1,37 @@
 """
-seed_leaderboard.py — Submit your local personal bests to the community leaderboard.
+seed_leaderboard.py — Submit all your personal bests to the community leaderboard.
 
-Useful if you set times before the leaderboard feature was configured, or if you
-want to re-sync your historical bests after a fresh install.
+Requires the F1 Lap Tracker app to be running (it handles the Azure connection).
 
 Usage:
-    python seed_leaderboard.py
+    python seed_leaderboard.py [port]
 
-The leaderboard only updates an entry if the submitted time is FASTER than the
-existing one, so running this multiple times is safe.
-
-Set F1_LEADERBOARD_URL env var if you host your own instance.
+    port  Optional. Default is 8080.
 """
 
 import json
-import os
-import sqlite3
-from datetime import datetime, timezone
+import sys
 from urllib.request import urlopen, Request as URLRequest
 
-# ── Config ────────────────────────────────────────────────────────────────────
-
-LEADERBOARD_URL = os.environ.get(
-    "F1_LEADERBOARD_URL",
-    "https://f1tracker-func-6v3lqkyuhxwkc.azurewebsites.net",
-).rstrip("/")
-if LEADERBOARD_URL.endswith("/api"):
-    LEADERBOARD_URL = LEADERBOARD_URL[:-4]
-
-DB_PATH = os.path.join(os.path.dirname(__file__), "f1_laps.db")
-
-
-def get_config():
-    """Read player_id and display_name from the app's config table."""
-    con = sqlite3.connect(DB_PATH)
-    def _get(key, default):
-        row = con.execute("SELECT value FROM config WHERE key=?", (key,)).fetchone()
-        return row[0] if row else default
-    player_id    = _get("player_id", None)
-    display_name = _get("display_name", "Anonymous")
-    con.close()
-    return player_id, display_name
-
-
-def get_all_pbs():
-    """Return all personal bests from the DB."""
-    con = sqlite3.connect(DB_PATH)
-    rows = con.execute(
-        "SELECT track, session_type, lap_time_ms, lap_time, compound "
-        "FROM personal_bests ORDER BY track, session_type"
-    ).fetchall()
-    con.close()
-    return rows
-
-
-def submit_time(player_id, display_name, track, session_type,
-                lap_time_ms, lap_time, compound) -> dict:
-    payload = json.dumps({
-        "player_id":    player_id,
-        "display_name": display_name,
-        "track":        track,
-        "session_type": session_type,
-        "lap_time_ms":  int(lap_time_ms),
-        "lap_time":     lap_time,
-        "compound":     compound or "",
-        "submitted_at": datetime.now(timezone.utc).isoformat(),
-    }).encode()
-
-    req = URLRequest(
-        f"{LEADERBOARD_URL}/api/lb-submit",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
-    try:
-        with urlopen(req, timeout=10) as resp:
-            return json.loads(resp.read())
-    except Exception as exc:
-        return {"ok": False, "error": str(exc)}
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8080
+BASE = f"http://localhost:{PORT}"
 
 
 def main():
-    player_id, display_name = get_config()
-    if not player_id:
-        print("No player_id found — start the app at least once first.")
+    print(f"Connecting to F1 Lap Tracker at {BASE}…")
+    req = URLRequest(f"{BASE}/api/lb-seed", data=b"", method="POST")
+    try:
+        with urlopen(req, timeout=15) as resp:
+            result = json.loads(resp.read())
+    except Exception as exc:
+        print(f"Error: {exc}")
+        print("Make sure the F1 Lap Tracker app is running before seeding.")
         return
 
-    pbs = get_all_pbs()
-    if not pbs:
-        print("No personal bests found in the DB — nothing to submit.")
-        return
-
-    print(f"Submitting {len(pbs)} personal best(s) as '{display_name}'...\n")
-    for track, session_type, lap_time_ms, lap_time, compound in pbs:
-        result = submit_time(player_id, display_name, track, session_type,
-                             lap_time_ms, lap_time, compound)
-        if result.get("ok"):
-            rank = result.get("rank", "?")
-            updated = result.get("updated", False)
-            note = f"rank #{rank}" + (" — new best!" if updated else " (no improvement)")
-        else:
-            note = f"FAILED: {result.get('error', '?')}"
-        print(f"  {track:30s} | {session_type:15s} | {lap_time:12s} → {note}")
-
-    print("\nDone.")
+    if result.get("ok"):
+        print(f"Done — submitted {result['submitted']} personal best(s) to the community leaderboard.")
+    else:
+        print(f"Server returned an error: {result}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The seed script was making direct HTTPS calls to Azure which failed with `unknown url type: 'https'` in some environments. The fix routes all Azure communication through the already-running local app server, which handles HTTPS fine.

- **`POST /api/lb-seed`** — new endpoint that calls `_lb_seed_all()`: reads every row from `personal_bests` and fires `_lb_post()` for each, reusing the same background-thread HTTPS code path that already works
- **SYNC MY TIMES button** added to the leaderboard tab controls (visible only when leaderboard is enabled); shows a count of submitted entries on completion and refreshes the community view
- **`seed_leaderboard.py`** stripped down to just `POST http://localhost:8080/api/lb-seed` — no direct Azure calls, no ssl issues

## Test plan

- [ ] Merge and `git pull`
- [ ] With the app running, click **SYNC MY TIMES** in the Leaderboard tab — button should show "SYNCED N" then revert
- [ ] Switch to COMMUNITY view — your submitted times should appear
- [ ] Optionally run `python seed_leaderboard.py` (app must be running) — should print "submitted N personal best(s)"

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS