### PR TITLE
Fix missing def _lb_refresh causing NameError on launch

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -941,6 +941,7 @@ def _lb_seed_all():
     return count
 
 
+def _lb_refresh(track_override=None, session_type_override=None):
     """Fetch leaderboard for the given (or current) track from Azure and cache in state."""
     if not LEADERBOARD_URL:
         return


### PR DESCRIPTION
## Summary

- Restores the `def _lb_refresh(track_override=None, session_type_override=None):` line that was accidentally dropped when `_lb_seed_all()` was inserted above it. The function body was still present but Python couldn't resolve the name, causing `NameError: name '_lb_refresh' is not defined` on launch.

## Test plan

- [ ] Merge and `git pull`
- [ ] App launches without error

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS