### PR TITLE
Fix 'All Session Types' blank render and Community auto-pick session type

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1896,22 +1896,25 @@ async function renderCommunity() {
     el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">Select a track above.</p></div>`;
     return;
   }
-  if (!_lbSessionType || _lbSessionType === 'all') {
-    el.innerHTML = `<div class="panel lb-wrap">
-      <div class="panel-title">Community — ${esc(_lbTrack)}</div>
-      <p style="color:var(--muted);font-size:.75rem;margin:8px 0">Select a specific session type to view community times.</p>
-    </div>`;
-    return;
+  // When 'All' is selected, pick the first session type the user has a PB in
+  let sessType = _lbSessionType;
+  if (!sessType || sessType === 'all') {
+    const firstPb = _lbPbs.find(p => p.track === _lbTrack);
+    if (!firstPb) {
+      el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">No times recorded for this track.</p></div>`;
+      return;
+    }
+    sessType = firstPb.session_type;
   }
   el.innerHTML = `<div class="panel lb-wrap">
-    <div class="panel-title">Community — ${esc(_lbTrack)} · ${esc(_lbSessionType)}</div>
+    <div class="panel-title">Community — ${esc(_lbTrack)} · ${esc(sessType)}</div>
     <p style="color:var(--muted);font-size:.75rem;margin:8px 0">Loading…</p>
   </div>`;
   try {
     await fetch('/api/lb-refresh', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ track: _lbTrack, session_type: _lbSessionType }),
+      body: JSON.stringify({ track: _lbTrack, session_type: sessType }),
     });
     await new Promise(r => setTimeout(r, 1800));
     const r = await fetch('/api/leaderboard');

--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1763,7 +1763,7 @@ document.addEventListener('DOMContentLoaded', () => {
 let _lbView        = 'mine';   // 'mine' | 'community'
 let _lbPbs         = [];       // all personal bests from DB
 let _lbTrack       = '';       // selected track name
-let _lbSessionType = '';       // selected session type
+let _lbSessionType = 'all';    // selected session type; 'all' = no filter
 
 async function fetchLeaderboard() {
   try {
@@ -1856,7 +1856,7 @@ function renderMyTimes() {
     el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">Select a track above.</p></div>`;
     return;
   }
-  const allTypes = _lbSessionType === 'all';
+  const allTypes = !_lbSessionType || _lbSessionType === 'all';
   const hits = allTypes
     ? _lbPbs.filter(p => p.track === _lbTrack)
     : _lbPbs.filter(p => p.track === _lbTrack && p.session_type === _lbSessionType);
@@ -1896,7 +1896,7 @@ async function renderCommunity() {
     el.innerHTML = `<div class="panel lb-wrap"><p style="color:var(--muted);font-size:.8rem;margin:8px 0">Select a track above.</p></div>`;
     return;
   }
-  if (_lbSessionType === 'all') {
+  if (!_lbSessionType || _lbSessionType === 'all') {
     el.innerHTML = `<div class="panel lb-wrap">
       <div class="panel-title">Community — ${esc(_lbTrack)}</div>
       <p style="color:var(--muted);font-size:.75rem;margin:8px 0">Select a specific session type to view community times.</p>


### PR DESCRIPTION
## Summary

Two fixes for the "All Session Types" option:

- **My Times + All**: was showing nothing on initial render because `_lbSessionType` initialised to `''` instead of `'all'`. Fixed by initialising to `'all'` and treating both `''` and `'all'` as show-all.
- **Community + All**: instead of showing an unhelpful prompt, now automatically picks the first session type the user has a PB in for that track and loads that community leaderboard.

## Test plan

- [ ] Merge and `git pull`
- [ ] Open Leaderboard tab — My Times shows all PBs for the selected track immediately
- [ ] Community with "All" loads the leaderboard for the first available session type

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS