### PR TITLE
Filter empty/Unknown track PBs from leaderboard — fixes 'All Session Types' showing wrong entry

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1771,8 +1771,11 @@ async function fetchLeaderboard() {
     _lbPbs = await r.json();
   } catch(e) { _lbPbs = []; }
 
-  // Drop records with no track name (incomplete sessions)
-  _lbPbs = _lbPbs.filter(pb => pb.track && pb.track !== 'Unknown');
+  // Drop records with no track or unknown/blank session type (incomplete sessions)
+  _lbPbs = _lbPbs.filter(pb =>
+    pb.track && pb.track !== 'Unknown' &&
+    pb.session_type && pb.session_type !== 'Unknown'
+  );
 
   // Most recently driven first
   _lbPbs.sort((a, b) => (b.set_at || '').localeCompare(a.set_at || ''));
@@ -3031,18 +3034,16 @@ class Handler(BaseHTTPRequestHandler):
             track_filter = qs.get("track", [None])[0]
             con = sqlite3.connect(DB_PATH)
             con.row_factory = sqlite3.Row
+            _valid = "track IS NOT NULL AND track != '' AND track != 'Unknown' " \
+                     "AND session_type IS NOT NULL AND session_type != '' AND session_type != 'Unknown'"
             if track_filter:
                 rows = con.execute(
-                    "SELECT * FROM personal_bests "
-                    "WHERE track=? AND track != '' AND track != 'Unknown' "
-                    "ORDER BY session_type",
+                    f"SELECT * FROM personal_bests WHERE track=? AND {_valid} ORDER BY session_type",
                     (track_filter,)
                 ).fetchall()
             else:
                 rows = con.execute(
-                    "SELECT * FROM personal_bests "
-                    "WHERE track IS NOT NULL AND track != '' AND track != 'Unknown' "
-                    "ORDER BY track, session_type"
+                    f"SELECT * FROM personal_bests WHERE {_valid} ORDER BY track, session_type"
                 ).fetchall()
             con.close()
             pbs = [dict(r) for r in rows]

--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1771,6 +1771,9 @@ async function fetchLeaderboard() {
     _lbPbs = await r.json();
   } catch(e) { _lbPbs = []; }
 
+  // Drop records with no track name (incomplete sessions)
+  _lbPbs = _lbPbs.filter(pb => pb.track && pb.track !== 'Unknown');
+
   // Most recently driven first
   _lbPbs.sort((a, b) => (b.set_at || '').localeCompare(a.set_at || ''));
 
@@ -3026,17 +3029,23 @@ class Handler(BaseHTTPRequestHandler):
         elif parsed.path == "/api/pbs":
             qs = parse_qs(parsed.query)
             track_filter = qs.get("track", [None])[0]
+            con = sqlite3.connect(DB_PATH)
+            con.row_factory = sqlite3.Row
             if track_filter:
-                con = sqlite3.connect(DB_PATH)
-                con.row_factory = sqlite3.Row
                 rows = con.execute(
-                    "SELECT * FROM personal_bests WHERE track=? ORDER BY session_type",
+                    "SELECT * FROM personal_bests "
+                    "WHERE track=? AND track != '' AND track != 'Unknown' "
+                    "ORDER BY session_type",
                     (track_filter,)
                 ).fetchall()
-                con.close()
-                pbs = [dict(r) for r in rows]
             else:
-                pbs = db_get_all_pbs()
+                rows = con.execute(
+                    "SELECT * FROM personal_bests "
+                    "WHERE track IS NOT NULL AND track != '' AND track != 'Unknown' "
+                    "ORDER BY track, session_type"
+                ).fetchall()
+            con.close()
+            pbs = [dict(r) for r in rows]
             payload = json.dumps(pbs).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

Root cause found: a PB record in the DB had an empty/null track name (from a session that ended before the track was properly identified by the game). This was defaulting `_lbTrack` to `''` or `'Unknown'`, so "All Session Types" only matched that one bad record.

- **JS**: filter out PBs with empty or `'Unknown'` track before building the dropdowns
- **Backend `/api/pbs`**: exclude empty/Unknown track rows from both the filtered and unfiltered queries

## Test plan

- [ ] Merge and `git pull`
- [ ] Open Leaderboard tab — track dropdown should not show a blank or "Unknown" option
- [ ] "All Session Types" should show all valid PBs for the selected track

https://claude.ai/code/session_01EktL3pxWME5cTshUqH7MbS