### PR TITLE
Docs: split self-hosting content into HOSTING.md

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -1,0 +1,101 @@
+# Self-Hosting the Pitwall IQ Backend
+
+This guide is for advanced users who want to run their own backend instead of using the shared Pitwall IQ service. Self-hosting gives you:
+
+- Unlimited AI debriefs (using your own Azure OpenAI deployment)
+- A private community leaderboard for your friend group
+- Full control over your data
+
+Everyone else — just run `F1_lap_tracker.py` and everything works out of the box.
+
+-----
+
+## Prerequisites
+
+**Linux / macOS:**
+
+```bash
+# Azure CLI
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash   # Ubuntu/Debian
+brew install azure-cli                                    # macOS
+
+# Azure Functions Core Tools
+npm install -g azure-functions-core-tools@4
+
+# jq (used by deploy.sh to parse output)
+sudo apt install jq   # Ubuntu/Debian
+brew install jq       # macOS
+
+az login
+```
+
+**Windows (PowerShell):**
+
+```powershell
+winget install Microsoft.AzureCLI
+winget install jqlang.jq
+npm install -g azure-functions-core-tools@4
+az login
+```
+
+> The deploy script (`infra/deploy.sh`) is a bash script. On Windows, run it from **Git Bash** or **WSL**.
+
+-----
+
+## Deploy the backend
+
+```bash
+cd infra
+chmod +x deploy.sh
+./deploy.sh <resource-group-name> <azure-region>
+# e.g.: ./deploy.sh pitwall-iq-rg eastus
+```
+
+The script will:
+1. Create the resource group
+2. Deploy Cosmos DB, Function App, and Storage Account via Bicep
+3. Publish the Python Azure Function
+4. Print the environment variables you need
+
+-----
+
+## Point the tracker at your backend
+
+Set these environment variables before starting the tracker (or add them to a `.env` file in the app folder):
+
+**Linux / macOS:**
+```bash
+export F1_LEADERBOARD_URL="https://<your-func>.azurewebsites.net"
+export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com"
+export AZURE_OPENAI_KEY="<your-api-key>"
+export AZURE_OPENAI_DEPLOYMENT="gpt-4o"
+python3 F1_lap_tracker.py
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:F1_LEADERBOARD_URL      = "https://<your-func>.azurewebsites.net"
+$env:AZURE_OPENAI_ENDPOINT   = "https://<your-resource>.openai.azure.com"
+$env:AZURE_OPENAI_KEY        = "<your-api-key>"
+$env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o"
+python F1_lap_tracker.py
+```
+
+-----
+
+## Sharing with friends
+
+Only one person needs to deploy. Everyone else sets the same `F1_LEADERBOARD_URL` value — no Azure account required for participants.
+
+-----
+
+## Estimated Azure cost
+
+| Resource | Estimated monthly cost |
+|---|---|
+| Cosmos DB (serverless) | ~$0–$1 for light use |
+| App Service Plan (B1 Basic) | ~$13/month |
+| Storage Account | < $0.10 |
+| **Total** | **~$13–$14/month** |
+
+> The Bicep uses a **Basic B1** dedicated plan rather than the consumption (Y1/Dynamic) tier. Many personal/trial Azure subscriptions have a Dynamic VM quota of 0, which blocks the consumption plan. B1 avoids that restriction entirely.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Each completed lap is written to `f1_laps.db` (SQLite) immediately. If the lap b
 
 The AI debrief feature is built in and works out of the box — no Azure account or API key required. Each player gets 10 debriefs per UTC day via the shared Pitwall IQ backend.
 
-If you want to host your own backend (unlimited debriefs, your own OpenAI deployment), see [Self-Hosting](#self-hosting) below.
+If you want to host your own backend (unlimited debriefs, your own OpenAI deployment), see [HOSTING.md](HOSTING.md).
 
 -----
 
@@ -236,95 +236,7 @@ If you want to host your own backend (unlimited debriefs, your own OpenAI deploy
 
 The community leaderboard is built in and works out of the box — no configuration required. Toggle **SUBMIT PBs** in the header to start sharing your times. Your PBs are only submitted when you explicitly opt in.
 
-If you want to host a private leaderboard for your own group, see [Self-Hosting](#self-hosting) below.
-
------
-
-## Self-Hosting
-
-This section is for advanced users who want to run their own backend (private leaderboard, unlimited AI debriefs, full data control).
-
-### Prerequisites
-
-**Linux / macOS:**
-
-```bash
-# Azure CLI
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash   # Ubuntu/Debian
-brew install azure-cli                                    # macOS
-
-# Azure Functions Core Tools
-npm install -g azure-functions-core-tools@4
-
-# jq (used by deploy.sh to parse output)
-sudo apt install jq   # Ubuntu/Debian
-brew install jq       # macOS
-
-az login
-```
-
-**Windows (PowerShell):**
-
-```powershell
-winget install Microsoft.AzureCLI
-winget install jqlang.jq
-npm install -g azure-functions-core-tools@4
-az login
-```
-
-> The deploy script (`infra/deploy.sh`) is a bash script. On Windows, run it from **Git Bash** or **WSL**.
-
-### Deploy the backend
-
-```bash
-cd infra
-chmod +x deploy.sh
-./deploy.sh <resource-group-name> <azure-region>
-# e.g.: ./deploy.sh pitwall-iq-rg eastus
-```
-
-The script will:
-1. Create the resource group
-2. Deploy Cosmos DB, Function App, and Storage Account via Bicep
-3. Publish the Python Azure Function
-4. Print the environment variables you need
-
-### Point the tracker at your backend
-
-Set these environment variables before starting the tracker (or add them to a `.env` file in the app folder):
-
-**Linux / macOS:**
-```bash
-export F1_LEADERBOARD_URL="https://<your-func>.azurewebsites.net"
-export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com"
-export AZURE_OPENAI_KEY="<your-api-key>"
-export AZURE_OPENAI_DEPLOYMENT="gpt-4o"
-python3 F1_lap_tracker.py
-```
-
-**Windows (PowerShell):**
-```powershell
-$env:F1_LEADERBOARD_URL      = "https://<your-func>.azurewebsites.net"
-$env:AZURE_OPENAI_ENDPOINT   = "https://<your-resource>.openai.azure.com"
-$env:AZURE_OPENAI_KEY        = "<your-api-key>"
-$env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o"
-python F1_lap_tracker.py
-```
-
-### Sharing with friends
-
-Only one person needs to deploy. Everyone else sets the same `F1_LEADERBOARD_URL` value — no Azure account required for participants.
-
-### Estimated Azure cost
-
-| Resource | Estimated monthly cost |
-|---|---|
-| Cosmos DB (serverless) | ~$0–$1 for light use |
-| App Service Plan (B1 Basic) | ~$13/month |
-| Storage Account | < $0.10 |
-| **Total** | **~$13–$14/month** |
-
-> The Bicep uses a **Basic B1** dedicated plan rather than the consumption (Y1/Dynamic) tier. Many personal/trial Azure subscriptions have a Dynamic VM quota of 0, which blocks the consumption plan. B1 avoids that restriction entirely.
+If you want to host a private leaderboard for your own group, see [HOSTING.md](HOSTING.md).
 
 -----
 


### PR DESCRIPTION
## Summary

- Moves all Azure/Bicep/OpenAI deployment instructions out of `README.md` into a new `HOSTING.md`
- `README.md` now stays focused on getting a beta tester running in under 5 minutes — no Azure noise
- Two inline "see Self-Hosting below" links updated to point to `HOSTING.md`

## Test plan

- [ ] Read through `README.md` end-to-end as if you're a Reddit beta tester — confirm nothing essential is missing
- [ ] Confirm `HOSTING.md` contains the complete Azure deployment steps, env vars, cost table, and sharing instructions
- [ ] Check that both `HOSTING.md` links in `README.md` render correctly on GitHub

https://claude.ai/code/session_01GnTJvayL4EAnbsSMs6y8yV