### PR TITLE
Docs: add MIT license, terms of use, and affiliation disclaimer

### DIFF
--- a/HOSTING.md
+++ b/HOSTING.md
@@ -1,0 +1,101 @@
+# Self-Hosting the Pitwall IQ Backend
+
+This guide is for advanced users who want to run their own backend instead of using the shared Pitwall IQ service. Self-hosting gives you:
+
+- Unlimited AI debriefs (using your own Azure OpenAI deployment)
+- A private community leaderboard for your friend group
+- Full control over your data
+
+Everyone else — just run `F1_lap_tracker.py` and everything works out of the box.
+
+-----
+
+## Prerequisites
+
+**Linux / macOS:**
+
+```bash
+# Azure CLI
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash   # Ubuntu/Debian
+brew install azure-cli                                    # macOS
+
+# Azure Functions Core Tools
+npm install -g azure-functions-core-tools@4
+
+# jq (used by deploy.sh to parse output)
+sudo apt install jq   # Ubuntu/Debian
+brew install jq       # macOS
+
+az login
+```
+
+**Windows (PowerShell):**
+
+```powershell
+winget install Microsoft.AzureCLI
+winget install jqlang.jq
+npm install -g azure-functions-core-tools@4
+az login
+```
+
+> The deploy script (`infra/deploy.sh`) is a bash script. On Windows, run it from **Git Bash** or **WSL**.
+
+-----
+
+## Deploy the backend
+
+```bash
+cd infra
+chmod +x deploy.sh
+./deploy.sh <resource-group-name> <azure-region>
+# e.g.: ./deploy.sh pitwall-iq-rg eastus
+```
+
+The script will:
+1. Create the resource group
+2. Deploy Cosmos DB, Function App, and Storage Account via Bicep
+3. Publish the Python Azure Function
+4. Print the environment variables you need
+
+-----
+
+## Point the tracker at your backend
+
+Set these environment variables before starting the tracker (or add them to a `.env` file in the app folder):
+
+**Linux / macOS:**
+```bash
+export F1_LEADERBOARD_URL="https://<your-func>.azurewebsites.net"
+export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com"
+export AZURE_OPENAI_KEY="<your-api-key>"
+export AZURE_OPENAI_DEPLOYMENT="gpt-4o"
+python3 F1_lap_tracker.py
+```
+
+**Windows (PowerShell):**
+```powershell
+$env:F1_LEADERBOARD_URL      = "https://<your-func>.azurewebsites.net"
+$env:AZURE_OPENAI_ENDPOINT   = "https://<your-resource>.openai.azure.com"
+$env:AZURE_OPENAI_KEY        = "<your-api-key>"
+$env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o"
+python F1_lap_tracker.py
+```
+
+-----
+
+## Sharing with friends
+
+Only one person needs to deploy. Everyone else sets the same `F1_LEADERBOARD_URL` value — no Azure account required for participants.
+
+-----
+
+## Estimated Azure cost
+
+| Resource | Estimated monthly cost |
+|---|---|
+| Cosmos DB (serverless) | ~$0–$1 for light use |
+| App Service Plan (B1 Basic) | ~$13/month |
+| Storage Account | < $0.10 |
+| **Total** | **~$13–$14/month** |
+
+> The Bicep uses a **Basic B1** dedicated plan rather than the consumption (Y1/Dynamic) tier. Many personal/trial Azure subscriptions have a Dynamic VM quota of 0, which blocks the consumption plan. B1 avoids that restriction entirely.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brian Turner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Each completed lap is written to `f1_laps.db` (SQLite) immediately. If the lap b
 
 The AI debrief feature is built in and works out of the box — no Azure account or API key required. Each player gets 10 debriefs per UTC day via the shared Pitwall IQ backend.
 
-If you want to host your own backend (unlimited debriefs, your own OpenAI deployment), see [Self-Hosting](#self-hosting) below.
+If you want to host your own backend (unlimited debriefs, your own OpenAI deployment), see [HOSTING.md](HOSTING.md).
 
 -----
 
@@ -236,95 +236,7 @@ If you want to host your own backend (unlimited debriefs, your own OpenAI deploy
 
 The community leaderboard is built in and works out of the box — no configuration required. Toggle **SUBMIT PBs** in the header to start sharing your times. Your PBs are only submitted when you explicitly opt in.
 
-If you want to host a private leaderboard for your own group, see [Self-Hosting](#self-hosting) below.
-
------
-
-## Self-Hosting
-
-This section is for advanced users who want to run their own backend (private leaderboard, unlimited AI debriefs, full data control).
-
-### Prerequisites
-
-**Linux / macOS:**
-
-```bash
-# Azure CLI
-curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash   # Ubuntu/Debian
-brew install azure-cli                                    # macOS
-
-# Azure Functions Core Tools
-npm install -g azure-functions-core-tools@4
-
-# jq (used by deploy.sh to parse output)
-sudo apt install jq   # Ubuntu/Debian
-brew install jq       # macOS
-
-az login
-```
-
-**Windows (PowerShell):**
-
-```powershell
-winget install Microsoft.AzureCLI
-winget install jqlang.jq
-npm install -g azure-functions-core-tools@4
-az login
-```
-
-> The deploy script (`infra/deploy.sh`) is a bash script. On Windows, run it from **Git Bash** or **WSL**.
-
-### Deploy the backend
-
-```bash
-cd infra
-chmod +x deploy.sh
-./deploy.sh <resource-group-name> <azure-region>
-# e.g.: ./deploy.sh pitwall-iq-rg eastus
-```
-
-The script will:
-1. Create the resource group
-2. Deploy Cosmos DB, Function App, and Storage Account via Bicep
-3. Publish the Python Azure Function
-4. Print the environment variables you need
-
-### Point the tracker at your backend
-
-Set these environment variables before starting the tracker (or add them to a `.env` file in the app folder):
-
-**Linux / macOS:**
-```bash
-export F1_LEADERBOARD_URL="https://<your-func>.azurewebsites.net"
-export AZURE_OPENAI_ENDPOINT="https://<your-resource>.openai.azure.com"
-export AZURE_OPENAI_KEY="<your-api-key>"
-export AZURE_OPENAI_DEPLOYMENT="gpt-4o"
-python3 F1_lap_tracker.py
-```
-
-**Windows (PowerShell):**
-```powershell
-$env:F1_LEADERBOARD_URL      = "https://<your-func>.azurewebsites.net"
-$env:AZURE_OPENAI_ENDPOINT   = "https://<your-resource>.openai.azure.com"
-$env:AZURE_OPENAI_KEY        = "<your-api-key>"
-$env:AZURE_OPENAI_DEPLOYMENT = "gpt-4o"
-python F1_lap_tracker.py
-```
-
-### Sharing with friends
-
-Only one person needs to deploy. Everyone else sets the same `F1_LEADERBOARD_URL` value — no Azure account required for participants.
-
-### Estimated Azure cost
-
-| Resource | Estimated monthly cost |
-|---|---|
-| Cosmos DB (serverless) | ~$0–$1 for light use |
-| App Service Plan (B1 Basic) | ~$13/month |
-| Storage Account | < $0.10 |
-| **Total** | **~$13–$14/month** |
-
-> The Bicep uses a **Basic B1** dedicated plan rather than the consumption (Y1/Dynamic) tier. Many personal/trial Azure subscriptions have a Dynamic VM quota of 0, which blocks the consumption plan. B1 avoids that restriction entirely.
+If you want to host a private leaderboard for your own group, see [HOSTING.md](HOSTING.md).
 
 -----
 

--- a/README.md
+++ b/README.md
@@ -277,3 +277,11 @@ If you want to host a private leaderboard for your own group, see [HOSTING.md](H
 - This app is built for **F1 25** but is compatible with F1 2023 and F1 2024 using the same UDP format.
 - Console versions (PlayStation, Xbox) can also broadcast telemetry to a PC on the same network — set the UDP IP to your PC's local IP instead of `127.0.0.1` and ensure both devices are on the same network.
 - No lap or session data is sent externally unless you enable the leaderboard opt-in toggle. The AI debrief sends only session metadata and lap times (no personal information) to the shared backend.
+
+-----
+
+## Disclaimer
+
+Pitwall IQ is an independent fan project and is **not affiliated with, endorsed by, or associated with Formula 1, Formula One Management Ltd (FOM), the FIA, Electronic Arts Inc. (EA), Codemasters, or any F1 team or driver.** F1, Formula 1, and related marks are trademarks of their respective owners.
+
+This software is provided "as is" without warranty of any kind. See [TERMS.md](TERMS.md) for full terms of use and privacy information.

--- a/TERMS.md
+++ b/TERMS.md
@@ -1,0 +1,73 @@
+# Terms of Use & Privacy Notice
+
+**Pitwall IQ** is an independent, open-source fan project. It is provided free of charge and carries no warranties. By downloading or using this software you agree to the following.
+
+---
+
+## Disclaimer of Affiliation
+
+**Pitwall IQ is not affiliated with, endorsed by, or associated with Formula 1, Formula One Management Ltd (FOM), the FIA, Electronic Arts Inc. (EA), Codemasters, or any F1 team or driver.**
+
+"F1", "Formula 1", team names, and related marks are trademarks of their respective owners. Any reference to those names in this software is purely for descriptive compatibility purposes (e.g. "compatible with F1 25 UDP telemetry").
+
+---
+
+## What the App Does
+
+Pitwall IQ reads UDP telemetry broadcast by F1 25 (or F1 24/23) on your own machine and displays it in a local browser dashboard. **All lap data is stored locally on your device** in a SQLite database (`f1_laps.db`). Nothing is sent externally unless you explicitly opt in to the features described below.
+
+---
+
+## Data Collection
+
+### Community Leaderboard (opt-in)
+
+If you enable the **SUBMIT PBs** toggle in the dashboard:
+
+- A randomly generated anonymous UUID (created locally on first run, stored in `f1_laps.db`) is sent alongside your lap times.
+- Track name, session type, lap time, and tyre compound are submitted to the shared Pitwall IQ backend (hosted on Microsoft Azure).
+- No name, email address, IP address, or any other personally identifying information is collected or stored by the backend.
+- You can disable submission at any time by toggling **SUBMIT PBs** off. Previously submitted times are not automatically deleted — contact the project maintainer via GitHub Issues to request removal.
+
+### AI Lap Debrief (on request)
+
+When you click **AI DEBRIEF**:
+
+- The current session's lap times, sector splits, track name, and session type are sent to the shared Pitwall IQ backend.
+- This data is used solely to generate the debrief and is not retained after the response is returned.
+- No personally identifying information is included in the request.
+
+### What is never collected
+
+- Your name, email, or any account credentials
+- Your F1 game account or EA account details
+- Your device identifiers or IP address
+- Any data from outside the Pitwall IQ app
+
+---
+
+## No Warranty
+
+This software is provided **"as is"**, without warranty of any kind, express or implied. The author makes no guarantees regarding accuracy of lap times, compatibility with future game versions, or uninterrupted availability of the shared backend. Use at your own risk.
+
+---
+
+## Shared Backend Availability
+
+The AI debrief and community leaderboard features depend on a shared backend hosted by the project maintainer. This service may be modified, rate-limited, or discontinued at any time without notice. If the backend is unavailable, all core lap tracking features continue to work normally — only the online features are affected.
+
+---
+
+## Changes to These Terms
+
+These terms may be updated at any time. The current version is always available in the project repository. Continued use of the software constitutes acceptance of any updated terms.
+
+---
+
+## Contact
+
+For data removal requests, bug reports, or other queries, open an issue at the project's GitHub repository.
+
+---
+
+*This document is not a substitute for legal advice. If you are uncertain about your obligations or rights, consult a qualified legal professional.*


### PR DESCRIPTION
## Summary

- **LICENSE** — MIT license
- **TERMS.md** — plain-English terms of use covering: what data is collected (leaderboard opt-in, AI debrief on-request only), what is never collected, no-warranty clause, shared backend availability caveat, and data removal process
- **README.md** — new Disclaimer section at the bottom making clear the project has no affiliation with Formula 1, EA, Codemasters, the FIA, or any F1 team

## Test plan

- [ ] Confirm the Disclaimer section renders correctly at the bottom of README.md on GitHub
- [ ] Read through TERMS.md and verify it accurately reflects how the leaderboard and AI debrief features actually work
- [ ] Verify LICENSE is detected correctly by GitHub (should show "MIT" on the repo homepage)
- [ ] Check your name/year in LICENSE is correct

> Note: TERMS.md is a good-faith effort for a beta but is not a substitute for legal review before a wider public launch.

https://claude.ai/code/session_01GnTJvayL4EAnbsSMs6y8yV