### PR TITLE
Feature: display name moderation and uniqueness enforcement

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -86,6 +86,7 @@ state = {
     "player_id": None,
     "leaderboard": None,       # cached community leaderboard response
     "leaderboard_enabled": False,  # True when LEADERBOARD_URL is set
+    "lb_error": None,              # set when the server rejects a submission
     "udp_connected": False,
     "player_position": 0,
     "total_laps": 0,
@@ -916,12 +917,15 @@ def _lb_post(payload, background=True):
                        method="POST")
             with urlopen(req, timeout=10) as resp:
                 result = json.loads(resp.read())
-                if result.get("rank"):
-                    with state_lock:
-                        lb = state.get("leaderboard") or {}
-                        lb["player_rank"] = result["rank"]
-                        state["leaderboard"] = lb
-                return result
+            if result.get("rank"):
+                with state_lock:
+                    lb = state.get("leaderboard") or {}
+                    lb["player_rank"] = result["rank"]
+                    state["leaderboard"] = lb
+            if not result.get("ok") and result.get("error"):
+                with state_lock:
+                    state["lb_error"] = result["error"]
+            return result
         except urllib.error.URLError as exc:
             log.debug("lb-submit URLError: %s", exc)
             _warn_backend_unreachable("Leaderboard")
@@ -1075,6 +1079,7 @@ def udp_listener():
 # Dashboard HTML is served from static/dashboard.html
 
 
+
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, *args): pass  # silence request logs
 
@@ -1119,6 +1124,7 @@ class Handler(BaseHTTPRequestHandler):
                 track_name = state["session"].get("track", "")
                 out = dict(state)
                 out["track_svg"] = TRACK_SVG.get(track_name)
+                state["lb_error"] = None  # clear after delivering to client
                 payload = json.dumps(out).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -131,6 +131,22 @@ resource cosmosContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/con
   }
 }
 
+resource displayNamesContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-02-15-preview' = {
+  parent: cosmosDatabase
+  name: 'display_names'
+  properties: {
+    resource: {
+      id: 'display_names'
+      partitionKey: {
+        paths: [
+          '/id'
+        ]
+        kind: 'Hash'
+      }
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // App Service Plan — Basic B1, Linux (dedicated; avoids Dynamic VM quota)
 // ---------------------------------------------------------------------------

--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -9,6 +9,9 @@ from datetime import datetime, timezone
 import azure.functions as func
 from azure.cosmos import CosmosClient, PartitionKey
 from azure.cosmos.exceptions import CosmosResourceNotFoundError
+from better_profanity import profanity as _profanity
+
+_profanity.load_censor_words()
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 
@@ -26,6 +29,7 @@ CORS_HEADERS = {
 DB_NAME = "f1tracker"
 LEADERBOARD_CONTAINER = "leaderboard"
 DEBRIEF_USAGE_CONTAINER = "debrief_usage"
+DISPLAY_NAMES_CONTAINER = "display_names"
 DAILY_DEBRIEF_LIMIT = 10
 DAILY_IP_DEBRIEF_LIMIT = 20   # higher limit per IP to allow shared networks
 
@@ -66,6 +70,45 @@ def _ms_to_laptime(ms) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Display-name helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_name(name: str) -> str:
+    """Lowercase + collapse whitespace — used as the uniqueness key."""
+    return " ".join(name.lower().split())
+
+
+def _check_and_register_name(display_name: str, player_id: str):
+    """Return an error string if the name is taken, otherwise register it.
+
+    Returns None on success, an error message string on conflict.
+    The display_names container may not exist on older deployments;
+    skip the check gracefully in that case.
+    """
+    normalized = _normalize_name(display_name)
+    try:
+        container = _get_container(DISPLAY_NAMES_CONTAINER)
+        try:
+            doc = container.read_item(item=normalized, partition_key=normalized)
+            if doc.get("player_id") != player_id:
+                return (
+                    f'The display name "{display_name}" is already taken. '
+                    "Please choose a different name."
+                )
+        except CosmosResourceNotFoundError:
+            container.upsert_item({
+                "id": normalized,
+                "player_id": player_id,
+                "display_name": display_name,
+            })
+    except Exception:
+        # Container missing or other infra issue — skip uniqueness check
+        # rather than blocking all submissions.
+        logger.warning("display_names container unavailable; skipping uniqueness check")
+    return None
+
+
+# ---------------------------------------------------------------------------
 # POST /api/lb-submit  (anonymous proxy — key stays server-side)
 # POST /api/submit     (kept for backwards compat, requires function key)
 # ---------------------------------------------------------------------------
@@ -94,6 +137,11 @@ def _handle_submit(body) -> func.HttpResponse:
         return _error("display_name must be between 1 and 32 characters.")
     if not all(c.isprintable() for c in display_name):
         return _error("display_name contains invalid characters.")
+    if _profanity.contains_profanity(display_name):
+        return _error("That display name isn't allowed. Please choose a different name.")
+    name_conflict = _check_and_register_name(display_name, player_id)
+    if name_conflict:
+        return _error(name_conflict)
     if not track or len(track) > 60:
         return _error("track must be between 1 and 60 characters.")
     if not session_type or len(session_type) > 30:

--- a/leaderboard_api/requirements.txt
+++ b/leaderboard_api/requirements.txt
@@ -1,2 +1,3 @@
 azure-functions
 azure-cosmos
+better-profanity==0.7.0

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1017,6 +1017,7 @@ async function fetchState() {
     const d = await r.json();
     lastData = d;
     render(d);
+    if (d.lb_error) showToast('⚠️  ' + d.lb_error, 'info', 6000);
   } catch(e) {}
 }
 


### PR DESCRIPTION
## Summary

Keeps the leaderboard safe for all ages and prevents name squatting.

- **Profanity filter** — `better-profanity` (server-side, can't be bypassed) rejects offensive display names including l33tspeak substitutions (sh1t, @ss, etc.)
- **Unique names** — first-come first-served: a new `display_names` Cosmos container maps normalised names (lowercased) to player UUIDs; the same player can always resubmit under their own name; a different player gets a clear "that name is taken" error
- **Graceful fallback** — if the `display_names` container is missing (e.g. an existing deployment that hasn't redeployed Bicep), the uniqueness check is skipped and submissions go through normally — nothing breaks
- **User-facing error toast** — when the server rejects a name, the error message surfaces as a dashboard toast notification rather than silently failing
- **Bicep** — `display_names` container added to `infra/main.bicep` for new deployments

## Deployment note

Existing self-hosters need to either redeploy via `./infra/deploy.sh` to get the new container, or create it manually in the Azure portal (Cosmos DB → your database → New Container, id=`display_names`, partition key=`/id`). Without it, uniqueness checks are skipped but everything else works.

## Test plan

- [ ] Submit a time with an offensive name → should get a 400 with "That display name isn't allowed"
- [ ] Submit with a clean name → should succeed and register the name
- [ ] Submit again with the same name from the same player UUID → should succeed
- [ ] Submit with that name from a *different* player UUID → should get "that name is taken"
- [ ] Try l33tspeak variants (sh1t, @ss, etc.) → should be caught
- [ ] Confirm the error toast appears in the dashboard when a name is rejected
- [ ] Confirm the toast only fires once (clears after first `/api/state` poll)

https://claude.ai/code/session_01GnTJvayL4EAnbsSMs6y8yV