### PR TITLE
Reorganize UI tabs + add gear, steering & RPM rev lights to RACE tab

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -96,6 +96,9 @@ state = {
     "car_throttle": 0.0,               # throttle input 0.0–1.0
     "car_brake": 0.0,                  # brake input 0.0–1.0
     "car_gear": 0,                     # current gear (-1=R, 0=N, 1–8)
+    "car_steer": 0.0,                  # steering input -1.0 (left) to 1.0 (right)
+    "car_rpm": 0,                      # engine RPM
+    "rev_lights_pct": 0,               # rev lights 0–100 (from game)
     "g_lat": 0.0,                      # lateral g-force
     "g_lon": 0.0,                      # longitudinal g-force
     "current_sector": 0,               # 0=S1, 1=S2, 2=S3
@@ -718,8 +721,10 @@ def parse_motion_packet(data, player_idx):
             state["g_lon"]   = round(g_lon, 3)
             spd      = state["car_speed"]
             throttle = state["car_throttle"]
+            steer    = state["car_steer"]
             brake    = state["car_brake"]
             gear     = state["car_gear"]
+            rpm      = state["car_rpm"]
             sector   = state["current_sector"]
             trace    = state["lap_trace"]
             # Subsample: only store a point if car has moved far enough
@@ -728,7 +733,8 @@ def parse_motion_packet(data, player_idx):
                     trace.append({
                         "x": round(x, 1), "z": round(z, 1),
                         "speed": spd, "sector": sector,
-                        "throttle": throttle, "brake": brake, "gear": gear,
+                        "throttle": throttle, "brake": brake,
+                        "steer": steer, "gear": gear, "rpm": rpm,
                         "gLat": round(g_lat, 2), "gLon": round(g_lon, 2),
                     })
     except Exception as e:
@@ -737,18 +743,25 @@ def parse_motion_packet(data, player_idx):
 def parse_car_telemetry_packet(data, player_idx):
     try:
         base = HEADER_SIZE + player_idx * CAR_TELEMETRY_SIZE
-        if len(data) < base + 16:
+        if len(data) < base + 20:
             return
-        # +0 speed(u16)  +2 throttle(f32)  +6 steer(f32)  +10 brake(f32)  +15 gear(i8)
-        speed    = struct.unpack_from("<H",  data, base +  0)[0]
-        throttle = struct.unpack_from("<f",  data, base +  2)[0]
-        brake    = struct.unpack_from("<f",  data, base + 10)[0]
-        gear     = struct.unpack_from("<b",  data, base + 15)[0]
+        # +0 speed(u16)  +2 throttle(f32)  +6 steer(f32)  +10 brake(f32)
+        # +14 clutch(u8) +15 gear(i8)  +16 engineRPM(u16)  +18 drs(u8)  +19 revLightsPct(u8)
+        speed          = struct.unpack_from("<H", data, base +  0)[0]
+        throttle       = struct.unpack_from("<f", data, base +  2)[0]
+        steer          = struct.unpack_from("<f", data, base +  6)[0]
+        brake          = struct.unpack_from("<f", data, base + 10)[0]
+        gear           = struct.unpack_from("<b", data, base + 15)[0]
+        rpm            = struct.unpack_from("<H", data, base + 16)[0]
+        rev_lights_pct = struct.unpack_from("<B", data, base + 19)[0]
         with state_lock:
-            state["car_speed"]    = int(speed)
-            state["car_throttle"] = round(max(0.0, min(1.0, throttle)), 3)
-            state["car_brake"]    = round(max(0.0, min(1.0, brake)),    3)
-            state["car_gear"]     = int(gear)
+            state["car_speed"]       = int(speed)
+            state["car_throttle"]    = round(max(0.0, min(1.0, throttle)), 3)
+            state["car_steer"]       = round(max(-1.0, min(1.0, steer)),   3)
+            state["car_brake"]       = round(max(0.0, min(1.0, brake)),    3)
+            state["car_gear"]        = int(gear)
+            state["car_rpm"]         = int(rpm)
+            state["rev_lights_pct"]  = int(rev_lights_pct)
     except Exception as e:
         log.debug("parse_car_telemetry: %s", e)
 
@@ -1246,10 +1259,12 @@ class Handler(BaseHTTPRequestHandler):
                     step = len(pts) // n
                     return pts[::step]
                 payload = json.dumps({
-                    "car_pos":       state["car_pos"],
-                    "car_speed":     state["car_speed"],
-                    "lap_trace":     _thin(trace),
-                    "track_outline": _thin(outline),
+                    "car_pos":        state["car_pos"],
+                    "car_speed":      state["car_speed"],
+                    "car_gear":       state["car_gear"],
+                    "rev_lights_pct": state["rev_lights_pct"],
+                    "lap_trace":      _thin(trace),
+                    "track_outline":  _thin(outline),
                 }).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -538,6 +538,18 @@ backdrop-filter: blur(4px);
       <button class="tab" id="tab-btn-leaderboard" onclick="switchTab('leaderboard')">LEADERBOARD</button>
     </div>
     <div id="tab-race">
+      <div id="rev-lights-section" class="panel" style="display:none;margin-bottom:8px;">
+        <div style="display:flex;align-items:center;gap:20px;">
+          <div style="text-align:center;min-width:48px;">
+            <div class="telem-label">GEAR</div>
+            <div id="live-gear" style="font-family:'Orbitron',sans-serif;font-size:2.8rem;font-weight:700;color:var(--fg);line-height:1;">N</div>
+          </div>
+          <div style="flex:1;">
+            <div class="telem-label" style="margin-bottom:6px;">RPM</div>
+            <canvas id="rev-lights-canvas" width="600" height="28" style="width:100%;display:block;border-radius:4px;"></canvas>
+          </div>
+        </div>
+      </div>
       <div id="telemetry-section" style="display:none;">
         <div class="panel">
           <div class="panel-title" id="telem-title">Telemetry</div>
@@ -547,6 +559,10 @@ backdrop-filter: blur(4px);
               <canvas id="speed-canvas" width="600" height="140" style="width:100%;display:block;"></canvas>
               <div class="telem-label" style="margin-top:10px;">THROTTLE &amp; BRAKE</div>
               <canvas id="inputs-canvas" width="600" height="100" style="width:100%;display:block;"></canvas>
+              <div class="telem-label" style="margin-top:10px;">GEAR</div>
+              <canvas id="gear-canvas" width="600" height="60" style="width:100%;display:block;"></canvas>
+              <div class="telem-label" style="margin-top:10px;">STEERING</div>
+              <canvas id="steer-canvas" width="600" height="70" style="width:100%;display:block;"></canvas>
             </div>
             <div class="telem-gforce-wrap">
               <div class="telem-label">G-FORCE</div>
@@ -1478,6 +1494,8 @@ function renderTelemetry(traceA, traceB = null) {
   }
   _renderSpeedChart(traceA, traceB);
   _renderInputsChart(traceA, traceB);
+  _renderGearChart(traceA, traceB);
+  _renderSteerChart(traceA, traceB);
   _renderGForceChart(traceA, traceB);
 }
 
@@ -1709,6 +1727,185 @@ function _renderGForceChartImpl(traceA, traceB) {
   }
 }
 
+// ── Gear chart ────────────────────────────────────────────────────────────────
+function _renderGearChart(traceA, traceB = null) {
+  const canvas = document.getElementById('gear-canvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const w = canvas.width, h = canvas.height;
+  ctx.clearRect(0, 0, w, h);
+  if (!traceA || traceA.length < 2) return;
+
+  const pad = _chartPad();
+  const cw = w - pad.l - pad.r, ch = h - pad.t - pad.b;
+  const MAX_GEAR = 8;
+
+  // Sector colour bar (reuse pattern from speed chart)
+  const nA = traceA.length;
+  let secStart = 0, lastSec = traceA[0].sector;
+  for (let i = 1; i <= nA; i++) {
+    if (i === nA || traceA[i].sector !== lastSec) {
+      const x1 = pad.l + (secStart / (nA - 1)) * cw;
+      const x2 = pad.l + (Math.min(i, nA - 1) / (nA - 1)) * cw;
+      ctx.fillStyle = _SECTOR_PALETTE[lastSec] || 'rgba(255,255,255,0.15)';
+      ctx.fillRect(x1, h - pad.b + 2, x2 - x1, 4);
+      if (i < nA) { lastSec = traceA[i].sector; secStart = i; }
+    }
+  }
+
+  function drawGearTrace(trace, fillColor, strokeColor) {
+    const n = trace.length;
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) {
+      const g = Math.max(0, trace[i].gear ?? 0);
+      const x = pad.l + (i / (n - 1)) * cw;
+      const y = pad.t + ch - (g / MAX_GEAR) * ch;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    // close fill path
+    ctx.lineTo(pad.l + cw, pad.t + ch);
+    ctx.lineTo(pad.l,      pad.t + ch);
+    ctx.closePath();
+    ctx.fillStyle = fillColor; ctx.fill();
+    // stroke
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) {
+      const g = Math.max(0, trace[i].gear ?? 0);
+      const x = pad.l + (i / (n - 1)) * cw;
+      const y = pad.t + ch - (g / MAX_GEAR) * ch;
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = strokeColor; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+  }
+
+  if (traceB && traceB.length >= 2) drawGearTrace(traceB, 'rgba(247,164,76,0.10)', '#f7a44c');
+  drawGearTrace(traceA, 'rgba(225,6,0,0.12)', '#e10600');
+
+  // Y-axis gear labels
+  ctx.fillStyle = 'rgba(255,255,255,0.28)'; ctx.font = '8px monospace';
+  for (let g = 2; g <= MAX_GEAR; g += 2) {
+    const y = pad.t + ch - (g / MAX_GEAR) * ch;
+    ctx.fillText(g, 0, y + 3);
+  }
+}
+
+// ── Steering chart ─────────────────────────────────────────────────────────────
+function _renderSteerChart(traceA, traceB = null) {
+  const canvas = document.getElementById('steer-canvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const w = canvas.width, h = canvas.height;
+  ctx.clearRect(0, 0, w, h);
+  if (!traceA || traceA.length < 2) return;
+
+  const pad = _chartPad();
+  const cw = w - pad.l - pad.r, ch = h - pad.t - pad.b;
+  const cy = pad.t + ch / 2; // zero line
+
+  // Sector colour bar
+  const nA = traceA.length;
+  let secStart = 0, lastSec = traceA[0].sector;
+  for (let i = 1; i <= nA; i++) {
+    if (i === nA || traceA[i].sector !== lastSec) {
+      const x1 = pad.l + (secStart / (nA - 1)) * cw;
+      const x2 = pad.l + (Math.min(i, nA - 1) / (nA - 1)) * cw;
+      ctx.fillStyle = _SECTOR_PALETTE[lastSec] || 'rgba(255,255,255,0.15)';
+      ctx.fillRect(x1, h - pad.b + 2, x2 - x1, 4);
+      if (i < nA) { lastSec = traceA[i].sector; secStart = i; }
+    }
+  }
+
+  // Zero centre line
+  ctx.strokeStyle = 'rgba(255,255,255,0.10)'; ctx.lineWidth = 1;
+  ctx.beginPath(); ctx.moveTo(pad.l, cy); ctx.lineTo(pad.l + cw, cy); ctx.stroke();
+
+  // Y-axis labels
+  ctx.fillStyle = 'rgba(255,255,255,0.28)'; ctx.font = '8px monospace';
+  ctx.fillText('L', 0, pad.t + 9);
+  ctx.fillText('R', 0, pad.t + ch);
+
+  function drawSteerTrace(trace, fillLeft, fillRight, strokeCol) {
+    const n = trace.length;
+    // Fill right turns (positive steer) above zero line
+    ctx.beginPath();
+    ctx.moveTo(pad.l, cy);
+    for (let i = 0; i < n; i++) {
+      const s = trace[i].steer ?? 0;
+      const x = pad.l + (i / (n - 1)) * cw;
+      const y = cy - (s / 1.0) * (ch / 2);
+      ctx.lineTo(x, y);
+    }
+    ctx.lineTo(pad.l + cw, cy); ctx.closePath();
+    ctx.fillStyle = fillRight; ctx.fill();
+    // Stroke
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) {
+      const s = trace[i].steer ?? 0;
+      const x = pad.l + (i / (n - 1)) * cw;
+      const y = cy - (s / 1.0) * (ch / 2);
+      i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+    }
+    ctx.strokeStyle = strokeCol; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+  }
+
+  if (traceB && traceB.length >= 2) drawSteerTrace(traceB, 'rgba(247,164,76,0.08)', 'rgba(247,164,76,0.08)', '#f7a44c');
+  drawSteerTrace(traceA, 'rgba(225,6,0,0.12)', 'rgba(225,6,0,0.12)', '#e10600');
+}
+
+// ── Rev lights (live) ─────────────────────────────────────────────────────────
+function renderRevLights(pct, gear) {
+  const section = document.getElementById('rev-lights-section');
+  const gearEl  = document.getElementById('live-gear');
+  const canvas  = document.getElementById('rev-lights-canvas');
+  if (!section || !canvas) return;
+
+  section.style.display = 'block';
+
+  // Update gear display
+  if (gearEl) {
+    const g = gear ?? 0;
+    gearEl.textContent = g === 0 ? 'N' : g < 0 ? 'R' : String(g);
+  }
+
+  // Draw 15-LED rev light strip (5 green, 5 yellow, 5 red)
+  const ctx = canvas.getContext('2d');
+  const w = canvas.width, h = canvas.height;
+  ctx.clearRect(0, 0, w, h);
+
+  const N = 15;
+  const lit = Math.round((pct / 100) * N);
+  const ledW = Math.floor(w / N);
+  const gap  = 3;
+
+  const COLOURS = [
+    '#22c55e','#22c55e','#22c55e','#22c55e','#22c55e',   // 5 green
+    '#facc15','#facc15','#facc15','#facc15','#facc15',   // 5 yellow
+    '#ef4444','#ef4444','#ef4444','#ef4444','#ef4444',   // 5 red
+  ];
+  const DIM = [
+    '#0a2e14','#0a2e14','#0a2e14','#0a2e14','#0a2e14',
+    '#2e2700','#2e2700','#2e2700','#2e2700','#2e2700',
+    '#2e0808','#2e0808','#2e0808','#2e0808','#2e0808',
+  ];
+
+  for (let i = 0; i < N; i++) {
+    const x = i * ledW + gap / 2;
+    const bw = ledW - gap;
+    ctx.fillStyle = i < lit ? COLOURS[i] : DIM[i];
+    ctx.beginPath();
+    const r = 3;
+    ctx.roundRect(x, 1, bw, h - 2, r);
+    ctx.fill();
+    // glow on lit LEDs
+    if (i < lit) {
+      ctx.shadowBlur = 8;
+      ctx.shadowColor = COLOURS[i];
+      ctx.fill();
+      ctx.shadowBlur = 0;
+    }
+  }
+}
+
 // ── Track Map ──────────────────────────────────────────────────────────────────
 let _mapMode         = 'sector';
 let _loadedSvg       = null;
@@ -1886,6 +2083,7 @@ async function fetchMotion() {
         }
       }
     }
+    renderRevLights(d.rev_lights_pct || 0, d.car_gear ?? 0);
     if (_reviewLap === null) {
       renderTrackMap(d);
       if (!_comparisonActive()) renderTelemetry(d.lap_trace || []);


### PR DESCRIPTION
## Summary

- **New RACE tab** (default active) focused on driving: shows live telemetry charts and the new rev-lights/gear panel, with lap history moved out of the way to a dedicated SESSION tab
- **Career stat counters fixed**: `/api/career` now reads stats directly from the DB on every request instead of stale in-memory state
- **Three new telemetry features** on the RACE tab: gear chart, steering chart, and live RPM rev lights

## Changes in detail

### UI reorganisation
- Added **RACE** tab as the primary tab (RACE → SESSION → CAREER → LEADERBOARD)
- RACE tab contains live telemetry charts — everything you need while driving
- SESSION tab now holds lap history table, A/B comparison bar, and AI debrief
- Telemetry chart heights increased (speed 72→140 px, throttle/brake 56→100 px, G-force 160→220 px) to use the extra space

### New telemetry — backend
- `parse_car_telemetry_packet` now reads **steering** (`steer`, offset +6), **engine RPM** (offset +16), and **rev-lights percent** (offset +19) from the Car Telemetry UDP packet
- `steer` and `rpm` are stored in each lap trace point so they appear in historical lap comparisons
- `car_gear` and `rev_lights_pct` are included in the `/api/motion` response (250 ms polling)

### New telemetry — frontend
- **Live rev-lights strip**: 15 LEDs (5 green → 5 yellow → 5 red) that fill up with the game's built-in `revLightsPercent` value, with glow effect on lit segments. Displayed alongside a large live gear number. Updates every 250 ms.
- **Gear chart**: step chart showing gear selected across the lap, sector-banded, supports A/B overlay
- **Steering chart**: centred line chart (−1 left / +1 right) showing steering inputs across the lap, supports A/B overlay
- Old lap traces without `steer`/`rpm` fields degrade gracefully via `?? 0`

### Bug fix
- Career stat counters (races, wins, podiums, points, fast laps, DNFs) were read from in-memory state which could be stale after an app restart. Now read fresh from the DB on every `/api/career` request.

## Test plan
- [ ] Launch app, open RACE tab — verify rev-lights panel shows gear "N" and all-dim LEDs before connecting
- [ ] Start a session in F1 25 — verify rev lights animate and gear number updates live
- [ ] Complete a lap — verify speed, throttle/brake, gear, steering, and G-force charts all render
- [ ] Switch to SESSION tab — verify lap history table and comparison bar are present
- [ ] Select two laps for A/B comparison — verify orange overlay appears on all five charts
- [ ] Open CAREER tab — verify stat counters show correct values from DB

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg