### PR TITLE
Docs: add telemetry chart preview to landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -389,6 +389,45 @@
     }
 
     code { font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace; }
+
+    /* ── Telemetry preview ── */
+    .tp-panel {
+      background: linear-gradient(145deg, var(--glass-hi) 0%, var(--glass) 100%);
+      border: 1px solid var(--glass-border);
+      border-radius: 14px;
+      padding: 1.25rem 1.5rem 1.5rem;
+      box-shadow: var(--shadow-card);
+      max-width: 900px;
+      margin: 0 auto;
+    }
+    .tp-title {
+      font-family: 'Cascadia Code', 'Fira Code', monospace;
+      font-size: 0.68rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 1rem;
+    }
+    .tp-badge {
+      background: rgba(255,215,0,0.15);
+      color: var(--gold);
+      border-radius: 4px;
+      padding: 1px 7px;
+      font-size: 0.65rem;
+      margin-left: 10px;
+    }
+    .tp-wrap { display: flex; gap: 14px; align-items: flex-start; }
+    .tp-charts { flex: 1; min-width: 0; }
+    .tp-gforce-wrap { width: 170px; flex-shrink: 0; }
+    .tp-label {
+      font-size: 0.6rem;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin-bottom: 3px;
+      margin-top: 10px;
+    }
+    .tp-label:first-child { margin-top: 0; }
   </style>
 </head>
 <body>
@@ -484,6 +523,30 @@
         </tr>
       </tbody>
     </table>
+  </div>
+</div>
+
+<!-- TELEMETRY PREVIEW -->
+<div class="container" style="padding-bottom:4rem;">
+  <p class="section-label" style="margin-bottom:1.5rem;">Telemetry charts</p>
+  <div class="tp-panel">
+    <div class="tp-title">Telemetry — Lap 7 <span class="tp-badge">TRACK PB ★</span></div>
+    <div class="tp-wrap">
+      <div class="tp-charts">
+        <div class="tp-label">Speed (km/h)</div>
+        <canvas id="tp-speed"  width="600" height="110" style="width:100%;display:block;"></canvas>
+        <div class="tp-label">Throttle &amp; Brake</div>
+        <canvas id="tp-inputs" width="600" height="80"  style="width:100%;display:block;"></canvas>
+        <div class="tp-label">Gear</div>
+        <canvas id="tp-gear"   width="600" height="52"  style="width:100%;display:block;"></canvas>
+        <div class="tp-label">Steering</div>
+        <canvas id="tp-steer"  width="600" height="60"  style="width:100%;display:block;"></canvas>
+      </div>
+      <div class="tp-gforce-wrap">
+        <div class="tp-label">G-Force</div>
+        <canvas id="tp-gforce" width="170" height="170" style="display:block;width:100%;"></canvas>
+      </div>
+    </div>
   </div>
 </div>
 
@@ -667,5 +730,249 @@
   <p style="margin-top: 0.4rem;">Not affiliated with Formula 1, FIA, or EA Sports.</p>
 </footer>
 
+<script>
+(function () {
+  // ── Synthetic lap trace (realistic F1 data) ────────────────────────────────
+  // Control points: [speed, throttle, brake, gear, steer, gLat, gLon, sector]
+  const ctrl = [
+    // ── S1: medium straight → DRS straight → heavy brake → hairpin ──
+    [185, 0.82, 0,    5,  0.00,  0.20, -0.60, 0],
+    [240, 1.00, 0,    6,  0.00,  0.10, -0.90, 0],
+    [292, 1.00, 0,    7,  0.00,  0.00, -1.00, 0],
+    [318, 1.00, 0,    8,  0.00,  0.00, -1.00, 0],
+    [318, 0.00, 1.00, 8,  0.10,  0.10,  3.50, 0],
+    [240, 0.00, 0.90, 6,  0.15,  0.30,  3.00, 0],
+    [138, 0.00, 0.65, 4,  0.30,  0.60,  2.00, 0],
+    [ 88, 0.00, 0.25, 2,  0.50,  1.20,  0.50, 0],
+    [ 70, 0.20, 0,    1,  0.65,  2.50,  0.00, 1],
+    [ 80, 0.50, 0,    2,  0.40,  1.80, -0.40, 1],
+    [118, 0.80, 0,    3,  0.15,  0.60, -0.70, 1],
+    [162, 1.00, 0,    4,  0.00,  0.20, -0.90, 1],
+    // ── S1 cont: medium right-hander ──
+    [185, 0.70, 0.10, 5,  0.38,  1.80,  0.10, 1],
+    [172, 0.60, 0,    4,  0.48,  2.30,  0.20, 1],
+    [182, 0.80, 0,    5,  0.20,  1.10, -0.30, 1],
+    [218, 1.00, 0,    5,  0.00,  0.20, -0.80, 1],
+    // ── S2: back straight → heavy brake → chicane ──
+    [252, 1.00, 0,    6,  0.00,  0.10, -0.90, 1],
+    [288, 1.00, 0,    7,  0.00,  0.00, -1.00, 1],
+    [322, 1.00, 0,    8,  0.00,  0.00, -1.00, 2],
+    [342, 1.00, 0,    8,  0.00,  0.00, -1.00, 2],
+    [342, 0.00, 1.00, 8,  0.20,  0.20,  4.00, 2],
+    [258, 0.00, 0.90, 6,  0.30,  0.50,  3.50, 2],
+    [158, 0.00, 0.60, 3,  0.40,  0.90,  2.00, 2],
+    [ 98, 0.00, 0.20, 2,  0.52,  1.50,  0.50, 2],
+    [ 86, 0.30, 0,    2,  0.62,  2.20, -0.20, 2],
+    [ 93, 0.40, 0,    2, -0.52, -1.80, -0.10, 2],
+    [112, 0.60, 0,    3, -0.28, -0.90, -0.50, 2],
+    [148, 0.90, 0,    4, -0.10, -0.30, -0.80, 2],
+    [188, 1.00, 0,    5,  0.00,  0.10, -0.90, 2],
+    // ── S2 cont: fast left-hander ──
+    [218, 0.85, 0,    5, -0.28, -1.60, -0.20, 2],
+    [208, 0.80, 0,    5, -0.32, -1.90,  0.00, 2],
+    [228, 0.90, 0,    5, -0.12, -0.80, -0.50, 2],
+    // ── S3: run to final complex → slow hairpin → finish ──
+    [258, 1.00, 0,    6,  0.00,  0.10, -0.90, 2],
+    [288, 1.00, 0,    7,  0.00,  0.00, -1.00, 2],
+    [288, 0.00, 0.90, 7,  0.28,  0.30,  3.20, 0],
+    [198, 0.00, 0.70, 5,  0.38,  0.70,  2.50, 0],
+    [118, 0.00, 0.40, 3,  0.52,  1.30,  1.20, 0],
+    [ 82, 0.00, 0.10, 2,  0.62,  2.00,  0.30, 0],
+    [ 76, 0.28, 0,    1,  0.72,  2.60, -0.10, 0],
+    [ 88, 0.55, 0,    2,  0.42,  1.50, -0.50, 0],
+    [128, 0.80, 0,    3,  0.12,  0.40, -0.80, 0],
+    [168, 0.95, 0,    4,  0.00,  0.20, -0.90, 0],
+    [198, 1.00, 0,    5,  0.00,  0.10, -0.90, 0],
+  ];
+
+  const N = 300;
+  const trace = [];
+  const cLen = ctrl.length - 1;
+  for (let i = 0; i < N; i++) {
+    const t   = (i / (N - 1)) * cLen;
+    const idx = Math.min(Math.floor(t), cLen - 1);
+    const f   = t - idx;
+    const a   = ctrl[idx], b = ctrl[idx + 1];
+    const L   = (ai) => a[ai] + (b[ai] - a[ai]) * f;
+    trace.push({
+      speed:    Math.round(L(0)),
+      throttle: +Math.max(0, Math.min(1, L(1))).toFixed(3),
+      brake:    +Math.max(0, Math.min(1, L(2))).toFixed(3),
+      gear:     Math.max(1, Math.min(8, Math.round(L(3)))),
+      steer:    +L(4).toFixed(3),
+      gLat:     +L(5).toFixed(3),
+      gLon:     +L(6).toFixed(3),
+      sector:   a[7],
+    });
+  }
+
+  // ── Shared helpers ─────────────────────────────────────────────────────────
+  const SEC_COL  = ['#e10600', '#f7c948', '#9b59b6'];
+  const PAD      = { t: 6, b: 14, l: 28, r: 4 };
+
+  function sectorBar(ctx, w, h) {
+    const n = trace.length, cw = w - PAD.l - PAD.r;
+    let s0 = 0, last = trace[0].sector;
+    for (let i = 1; i <= n; i++) {
+      if (i === n || trace[i].sector !== last) {
+        const x1 = PAD.l + (s0 / (n - 1)) * cw;
+        const x2 = PAD.l + (Math.min(i, n - 1) / (n - 1)) * cw;
+        ctx.fillStyle = SEC_COL[last];
+        ctx.fillRect(x1, h - PAD.b + 2, x2 - x1, 4);
+        if (i < n) { last = trace[i].sector; s0 = i; }
+      }
+    }
+  }
+
+  function lineChart(ctx, w, h, vals, fillCol, strokeCol) {
+    const n = trace.length, cw = w - PAD.l - PAD.r, ch = h - PAD.t - PAD.b;
+    const mn = Math.min(...vals), mx = Math.max(...vals, mn + 1), rng = mx - mn;
+    const x = (i) => PAD.l + (i / (n - 1)) * cw;
+    const y = (v) => PAD.t + ch - ((v - mn) / rng) * ch;
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) i === 0 ? ctx.moveTo(x(i), y(vals[i])) : ctx.lineTo(x(i), y(vals[i]));
+    ctx.lineTo(x(n - 1), PAD.t + ch); ctx.lineTo(PAD.l, PAD.t + ch); ctx.closePath();
+    ctx.fillStyle = fillCol; ctx.fill();
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) i === 0 ? ctx.moveTo(x(i), y(vals[i])) : ctx.lineTo(x(i), y(vals[i]));
+    ctx.strokeStyle = strokeCol; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+    return { x, y, mn, mx, rng, cw, ch };
+  }
+
+  // ── Speed chart ────────────────────────────────────────────────────────────
+  function drawSpeed() {
+    const canvas = document.getElementById('tp-speed');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width, h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    const speeds = trace.map(p => p.speed);
+    const mn = Math.min(...speeds), mx = Math.max(...speeds);
+    const ch = h - PAD.t - PAD.b;
+    for (let v = Math.ceil(mn / 50) * 50; v <= mx; v += 50) {
+      const yy = PAD.t + ch - ((v - mn) / (mx - mn)) * ch;
+      ctx.strokeStyle = 'rgba(255,255,255,0.06)'; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(PAD.l, yy); ctx.lineTo(w - PAD.r, yy); ctx.stroke();
+      ctx.fillStyle = 'rgba(255,255,255,0.28)'; ctx.font = '8px monospace';
+      ctx.fillText(v, 0, yy + 3);
+    }
+    sectorBar(ctx, w, h);
+    lineChart(ctx, w, h, speeds, 'rgba(225,6,0,0.12)', '#e10600');
+  }
+
+  // ── Throttle & Brake chart ─────────────────────────────────────────────────
+  function drawInputs() {
+    const canvas = document.getElementById('tp-inputs');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width, h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    sectorBar(ctx, w, h);
+    const n = trace.length, cw = w - PAD.l - PAD.r, ch = h - PAD.t - PAD.b;
+    const xv = (i) => PAD.l + (i / (n - 1)) * cw;
+    const yv = (v) => PAD.t + ch - v * ch;
+    // Throttle
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) i === 0 ? ctx.moveTo(xv(i), yv(trace[i].throttle)) : ctx.lineTo(xv(i), yv(trace[i].throttle));
+    ctx.lineTo(xv(n - 1), PAD.t + ch); ctx.lineTo(PAD.l, PAD.t + ch); ctx.closePath();
+    ctx.fillStyle = 'rgba(39,174,96,0.22)'; ctx.fill();
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) i === 0 ? ctx.moveTo(xv(i), yv(trace[i].throttle)) : ctx.lineTo(xv(i), yv(trace[i].throttle));
+    ctx.strokeStyle = '#27ae60'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+    // Brake
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) i === 0 ? ctx.moveTo(xv(i), yv(trace[i].brake)) : ctx.lineTo(xv(i), yv(trace[i].brake));
+    ctx.lineTo(xv(n - 1), PAD.t + ch); ctx.lineTo(PAD.l, PAD.t + ch); ctx.closePath();
+    ctx.fillStyle = 'rgba(231,76,60,0.22)'; ctx.fill();
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) i === 0 ? ctx.moveTo(xv(i), yv(trace[i].brake)) : ctx.lineTo(xv(i), yv(trace[i].brake));
+    ctx.strokeStyle = '#e74c3c'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+    ctx.font = '8px monospace';
+    ctx.fillStyle = 'rgba(39,174,96,0.9)';  ctx.fillText('T', 0, PAD.t + 9);
+    ctx.fillStyle = 'rgba(231,76,60,0.9)';  ctx.fillText('B', 0, PAD.t + ch);
+  }
+
+  // ── Gear chart ─────────────────────────────────────────────────────────────
+  function drawGear() {
+    const canvas = document.getElementById('tp-gear');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width, h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    sectorBar(ctx, w, h);
+    const MAX = 8;
+    const { ch } = lineChart(ctx, w, h, trace.map(p => Math.max(0, p.gear)), 'rgba(225,6,0,0.12)', '#e10600');
+    ctx.font = '8px monospace'; ctx.fillStyle = 'rgba(255,255,255,0.28)';
+    const realCh = h - PAD.t - PAD.b;
+    for (let g = 2; g <= MAX; g += 2)
+      ctx.fillText(g, 0, PAD.t + realCh - (g / MAX) * realCh + 3);
+  }
+
+  // ── Steering chart ─────────────────────────────────────────────────────────
+  function drawSteer() {
+    const canvas = document.getElementById('tp-steer');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width, h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    sectorBar(ctx, w, h);
+    const n = trace.length, cw = w - PAD.l - PAD.r, ch = h - PAD.t - PAD.b;
+    const cy = PAD.t + ch / 2;
+    ctx.strokeStyle = 'rgba(255,255,255,0.10)'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(PAD.l, cy); ctx.lineTo(PAD.l + cw, cy); ctx.stroke();
+    ctx.font = '8px monospace'; ctx.fillStyle = 'rgba(255,255,255,0.28)';
+    ctx.fillText('L', 0, PAD.t + 9); ctx.fillText('R', 0, PAD.t + ch);
+    const xv = (i) => PAD.l + (i / (n - 1)) * cw;
+    const yv = (v) => cy - v * (ch / 2);
+    ctx.beginPath(); ctx.moveTo(PAD.l, cy);
+    for (let i = 0; i < n; i++) ctx.lineTo(xv(i), yv(trace[i].steer));
+    ctx.lineTo(xv(n - 1), cy); ctx.closePath();
+    ctx.fillStyle = 'rgba(225,6,0,0.12)'; ctx.fill();
+    ctx.beginPath();
+    for (let i = 0; i < n; i++) i === 0 ? ctx.moveTo(xv(i), yv(trace[i].steer)) : ctx.lineTo(xv(i), yv(trace[i].steer));
+    ctx.strokeStyle = '#e10600'; ctx.lineWidth = 1.5; ctx.lineJoin = 'round'; ctx.stroke();
+  }
+
+  // ── G-Force chart ──────────────────────────────────────────────────────────
+  function drawGForce() {
+    const canvas = document.getElementById('tp-gforce');
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    const w = canvas.width, h = canvas.height;
+    ctx.clearRect(0, 0, w, h);
+    const cx = w / 2, cy = h / 2, maxG = 4.0;
+    const sc = Math.min(cx, cy) - 10;
+    ctx.strokeStyle = 'rgba(255,255,255,0.12)'; ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.arc(cx, cy, sc, 0, Math.PI * 2); ctx.stroke();
+    ctx.strokeStyle = 'rgba(255,255,255,0.06)';
+    ctx.beginPath(); ctx.arc(cx, cy, sc * (2 / maxG), 0, Math.PI * 2); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(cx - sc, cy); ctx.lineTo(cx + sc, cy); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(cx, cy - sc); ctx.lineTo(cx, cy + sc); ctx.stroke();
+    ctx.fillStyle = 'rgba(255,255,255,0.18)'; ctx.font = '8px monospace';
+    ctx.fillText('4G', cx + 3, cy - sc + 9);
+    const clamp = (v) => Math.max(-sc, Math.min(sc, v));
+    for (const p of trace) {
+      const px = cx + clamp((p.gLat / maxG) * sc);
+      const py = cy - clamp((p.gLon / maxG) * sc);
+      ctx.fillStyle = SEC_COL[p.sector] + '99';
+      ctx.beginPath(); ctx.arc(px, py, 1.5, 0, Math.PI * 2); ctx.fill();
+    }
+    // Current position dot
+    const last = trace[trace.length - 1];
+    const lpx = cx + clamp((last.gLat / maxG) * sc);
+    const lpy = cy - clamp((last.gLon / maxG) * sc);
+    ctx.shadowBlur = 8; ctx.shadowColor = '#fff';
+    ctx.fillStyle = '#fff';
+    ctx.beginPath(); ctx.arc(lpx, lpy, 3, 0, Math.PI * 2); ctx.fill();
+    ctx.shadowBlur = 0;
+  }
+
+  drawSpeed();
+  drawInputs();
+  drawGear();
+  drawSteer();
+  drawGForce();
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds a live telemetry chart preview to the landing page (`docs/index.html`), sitting between the lap table preview and the features grid — mirroring the same visual showcase approach.

## Changes

All five telemetry charts are drawn on canvas using synthetic but realistic F1 lap data, rendered in the same style as the actual dashboard:

- **Speed** — km/h trace with grid lines and sector colour bands
- **Throttle & Brake** — green throttle and red brake overlaid with T/B labels
- **Gear** — step chart with Y-axis gear number labels
- **Steering** — centred line chart with L/R labels showing left/right lock
- **G-Force** — sector-coloured scatter plot with 2G reference ring and white position dot

The synthetic data includes three hard braking zones, a chicane, a fast left-hander, and slow hairpins to look convincing rather than like a test pattern. CSS panel styling matches the existing lap table preview.

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg