### PR TITLE
Add interactive lap review in SESSION tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A lightweight local lap time tracker for **F1 25** (and F1 24/23) on PC. Capture
 - **Session storage** — every session and lap is automatically saved to a local SQLite database (`f1_laps.db`) so your data persists between runs
 - **Toast notifications** — pop-up alerts for new track PBs and sector bests
 - **Lap comparison overlay** — select any two laps from the table to compare their speed, inputs, gear, steering, and G-force side-by-side
+- **Interactive lap review** — click any lap row in the SESSION tab to instantly load its full telemetry inline below the table; click the same row again (or ✕ CLOSE) to dismiss
 - **Live track map** — animated car position with sector colouring or speed heatmap; browse any previous lap with the arrow navigation
 - **Live telemetry charts** — speed trace, throttle & brake inputs, gear step chart, steering chart, and G-force circle updated in real time
 - **Rev-lights strip** — live RPM indicator using the game's built-in rev-light percentage, with a large gear number display updated every 250 ms
@@ -130,6 +131,10 @@ Shows your lap history and comparison tools for the current session.
 | **TIME** | Lap time. `★` = session best. `🏆` = new all-time track PB. |
 | **DELTA** | Gap to track PB (purple `PB!` if this lap set a new record); falls back to session best if no prior PB exists |
 | **S1 / S2 / S3** | Sector split times. Best sector each session is highlighted with a purple cell background. |
+
+#### Inline lap telemetry review
+
+Click any row in the lap table to load that lap's full telemetry directly below the table (speed, throttle & brake, gear, steering, and G-force). The selected row is highlighted. Click the same row again or press **✕ CLOSE** to dismiss.
 
 #### Lap comparison
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ A lightweight local lap time tracker for **F1 25** (and F1 24/23) on PC. Capture
 - **Session info** — track name, session type (Race, Qualifying, Practice, etc.), and weather pulled live from telemetry
 - **Session storage** — every session and lap is automatically saved to a local SQLite database (`f1_laps.db`) so your data persists between runs
 - **Toast notifications** — pop-up alerts for new track PBs and sector bests
-- **Lap comparison overlay** — select any two laps from the table to compare their speed, inputs, and G-force side-by-side
+- **Lap comparison overlay** — select any two laps from the table to compare their speed, inputs, gear, steering, and G-force side-by-side
 - **Live track map** — animated car position with sector colouring or speed heatmap; browse any previous lap with the arrow navigation
-- **Live telemetry charts** — speed trace, throttle & brake inputs, and a G-force circle updated in real time
+- **Live telemetry charts** — speed trace, throttle & brake inputs, gear step chart, steering chart, and G-force circle updated in real time
+- **Rev-lights strip** — live RPM indicator using the game's built-in rev-light percentage, with a large gear number display updated every 250 ms
 - **Career stats tab** — tracks race results (position, points, grid, fastest lap) across every session; shows wins, podiums, points total, and DNFs
 - **Past sessions panel** — browse all previous sessions directly in the dashboard (collapsible)
 - **CSV export** — download the current session or any past session as a CSV file
@@ -91,46 +92,48 @@ Start the launcher before or after launching F1 25 — order doesn't matter. Onc
 | **SUBMIT PBs toggle** | Enable or disable sharing your PBs with the community leaderboard (opt-in only). |
 | **Display name** | Set the name shown next to your times on the community leaderboard. |
 
-### Session tab
+### RACE tab (default)
 
-The default view. Shows the live lap table, telemetry charts, track map, personal bests, and past sessions.
+The default view, designed for use while driving. Shows the live rev-lights panel and telemetry charts. The track map and all session stats are always visible in the left sidebar regardless of which tab is active.
+
+#### Rev-lights panel
+
+Always shown once UDP telemetry is connected. Displays:
+
+- **Gear number** — large live readout of the current gear (`R`, `N`, `1`–`8`)
+- **Rev-lights strip** — 15 LEDs that fill left-to-right using the game's built-in rev-light percentage; colours progress green → yellow → red with a glow effect on lit segments. Updated every 250 ms.
+
+#### Telemetry charts
+
+Updated live every 250 ms as you drive. After your first lap completes, the full trace is drawn:
+
+| Chart | Description |
+|---|---|
+| **Speed** | km/h across the lap distance, sector-banded |
+| **Throttle & Brake** | Throttle (green) and brake (red) inputs 0–100% |
+| **Gear** | Step chart showing which gear was selected at each point in the lap |
+| **Steering** | Centred line chart; positive = right lock, negative = left lock |
+| **G-Force circle** | Lateral vs. longitudinal G, dots coloured by sector; inner ring = 2G reference |
+
+Use the track map **← →** buttons to review any previous lap's telemetry. In **comparison mode**, the selected lap (A) is drawn in its normal colour; the reference lap (B) is overlaid in orange/amber across all five charts.
+
+### SESSION tab
+
+Shows your lap history and comparison tools for the current session.
 
 #### Lap table
 
-Each lap row shows:
-
 | Column | Description |
 |---|---|
-| **LAP** | Lap number. Click any row to select it for lap comparison (slots A or B). |
+| **LAP** | Lap number |
 | **TYRE** | Compound pill — `S` Soft (red), `M` Medium (yellow), `H` Hard (white), `I` Inter (green), `W` Wet (blue) |
 | **TIME** | Lap time. `★` = session best. `🏆` = new all-time track PB. |
 | **DELTA** | Gap to track PB (purple `PB!` if this lap set a new record); falls back to session best if no prior PB exists |
 | **S1 / S2 / S3** | Sector split times. Best sector each session is highlighted with a purple cell background. |
 
-#### Telemetry charts
-
-Displayed below the lap table. Updated live every 250 ms:
-
-- **Speed trace** — km/h across the lap distance, coloured by sector
-- **Throttle & Brake** — green = throttle, red = brake input (0–100%)
-- **G-Force circle** — lateral vs. longitudinal G, dots coloured by sector; inner ring = 2G reference
-
-Use the track map **← →** buttons to review any previous lap's telemetry. In **comparison mode**, the selected lap (A) is shown in blue/green/red on top of the reference lap (B) in orange/amber.
-
-#### Track map
-
-Live animated car position plotted from motion telemetry. Two display modes:
-
-| Mode | Description |
-|---|---|
-| **S1/S2/S3** | Trace coloured by sector (blue/yellow/red) |
-| **SPEED** | Heatmap from slow (blue) to fast (red) |
-
-Use the **← →** arrows beneath the map to step through previous laps. Click **LIVE** to return to the real-time view.
-
 #### Lap comparison
 
-Click a lap row to assign it to slot **A**, then click another to assign slot **B**. The comparison bar shows both lap numbers and the telemetry panel switches to overlay mode. Click **CLEAR** to exit comparison and return to live view.
+Click **A** or **B** next to any lap to assign it to a comparison slot. The comparison bar shows both laps and the RACE tab telemetry switches to overlay mode across all charts. Click **CLEAR** to exit.
 
 #### Personal Bests panel
 
@@ -215,7 +218,7 @@ F1 25 broadcasts UDP packets on your local network containing real-time telemetr
   - Packet ID 1 (Session Data) — track, session type, weather
   - Packet ID 2 (Lap Data) — lap times and sector splits
   - Packet ID 3 (Event) — fastest lap detection (FTLP event)
-  - Packet ID 6 (Car Telemetry) — speed, throttle, brake, and gear for telemetry charts
+  - Packet ID 6 (Car Telemetry) — speed, throttle, brake, gear, steering, RPM, and rev-lights percent for telemetry charts and the live rev-lights panel
   - Packet ID 7 (Car Status) — tyre compound
   - Packet ID 8 (Final Classification) — race finishing position, points, and result status
 - **HTTP server** on port `5000` — serves the dashboard and API endpoints; the browser polls `/api/state` every second

--- a/docs/index.html
+++ b/docs/index.html
@@ -535,11 +535,6 @@
         <p>Session best highlighted in gold. All-time track PBs stored per track and session type — Monaco Qualifying and Monaco Race kept separately.</p>
       </div>
       <div class="card">
-        <div class="card-icon">&#127937;</div>
-        <h3>Team themes</h3>
-        <p>Choose a colour theme for all 10 F1 2025 constructors from a dropdown in the header. Preference is saved in the browser.</p>
-      </div>
-      <div class="card">
         <div class="card-icon">&#128276;</div>
         <h3>Toast notifications</h3>
         <p>Instant pop-up alerts when you set a new track PB or beat your best sector time.</p>

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -256,6 +256,10 @@ tbody tr:hover { background: rgba(255,255,255,.05); }
 tbody tr.best-lap { background: rgba(255,215,0,.07); }
 tbody tr.track-pb-lap { background: rgba(199,125,255,.07); }
 tbody tr.invalid { opacity: .4; }
+tbody tr.lap-selected td { background: rgba(255,255,255,.10) !important; }
+tbody tr.lap-selected { outline: 1px solid rgba(255,255,255,.22); cursor: pointer; }
+tbody tr { cursor: pointer; }
+tbody tr:hover td { background: rgba(255,255,255,.04); }
 td { padding: 7px 8px; }
 td.lap-num { color: var(--muted); font-size: .7rem; }
 td.lap-time { font-family: 'Orbitron', sans-serif; font-size: .85rem; color: var(--text); }
@@ -584,6 +588,31 @@ backdrop-filter: blur(4px);
       <button onclick="clearComparison()" style="margin-left:auto;font-size:.6rem;color:var(--muted);background:none;border:1px solid var(--border);border-radius:2px;padding:2px 8px;cursor:pointer;">CLEAR</button>
     </div>
     <div id="lap-table"></div>
+    <div id="session-review-section" style="display:none;margin-top:12px;">
+      <div class="panel">
+        <div class="panel-title" style="display:flex;justify-content:space-between;align-items:center;">
+          <span>Telemetry — Lap <span id="session-review-title">—</span></span>
+          <button onclick="closeSessionReview()" style="font-size:.6rem;color:var(--muted);background:none;border:1px solid var(--border);border-radius:2px;padding:2px 8px;cursor:pointer;">✕ CLOSE</button>
+        </div>
+        <div id="session-review-waiting" style="display:flex;align-items:center;justify-content:center;height:80px;color:var(--muted);font-size:.8rem;letter-spacing:.1em;">Loading trace…</div>
+        <div id="session-review-charts" class="telem-wrap" style="display:none;">
+          <div class="telem-charts">
+            <div class="telem-label">SPEED (km/h)</div>
+            <canvas id="speed-canvas-sr" width="600" height="140" style="width:100%;display:block;"></canvas>
+            <div class="telem-label" style="margin-top:10px;">THROTTLE &amp; BRAKE</div>
+            <canvas id="inputs-canvas-sr" width="600" height="100" style="width:100%;display:block;"></canvas>
+            <div class="telem-label" style="margin-top:10px;">GEAR</div>
+            <canvas id="gear-canvas-sr" width="600" height="60" style="width:100%;display:block;"></canvas>
+            <div class="telem-label" style="margin-top:10px;">STEERING</div>
+            <canvas id="steer-canvas-sr" width="600" height="70" style="width:100%;display:block;"></canvas>
+          </div>
+          <div class="telem-gforce-wrap">
+            <div class="telem-label">G-FORCE</div>
+            <canvas id="gforce-canvas-sr" width="220" height="220" style="display:block;width:100%;"></canvas>
+          </div>
+        </div>
+      </div>
+    </div>
     <div id="debrief-section"></div>
     </div><!-- end tab-session -->
     <div id="tab-career" style="display:none">
@@ -1111,6 +1140,7 @@ function _checkToasts(laps) {
 
 // ── Lap comparison ────────────────────────────────────────────────────────────
 let _compareA = null, _compareB = null;
+let _selectedSessionLap = null;
 let _compareTraceA = null, _compareTraceB = null;
 
 function _updateCompBar() {
@@ -1168,6 +1198,47 @@ function _renderComparisonOrLive() {
 
 function _comparisonActive() {
   return _compareA !== null || _compareB !== null;
+}
+
+// ── Session lap review ────────────────────────────────────────────────────────
+async function selectSessionLap(lapNum) {
+  if (_selectedSessionLap === lapNum) {
+    closeSessionReview();
+    return;
+  }
+  _selectedSessionLap = lapNum;
+  if (lastData) render(lastData);
+
+  const sec = document.getElementById('session-review-section');
+  const waiting = document.getElementById('session-review-waiting');
+  const charts = document.getElementById('session-review-charts');
+  const title = document.getElementById('session-review-title');
+  if (!sec) return;
+  sec.style.display = 'block';
+  sec.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  if (waiting) waiting.style.display = 'flex';
+  if (charts) charts.style.display = 'none';
+  if (title) title.textContent = lapNum;
+
+  const sid = _sessionId;
+  if (!sid) return;
+  try {
+    const r = await fetch(`/api/lap-trace/${sid}/${lapNum}`);
+    const d = await r.json();
+    const trace = d.trace || [];
+    if (waiting) waiting.style.display = 'none';
+    if (charts) charts.style.display = '';
+    renderTelemetry(trace, null, '-sr');
+  } catch(e) {
+    if (waiting) waiting.textContent = 'Failed to load trace.';
+  }
+}
+
+function closeSessionReview() {
+  _selectedSessionLap = null;
+  const sec = document.getElementById('session-review-section');
+  if (sec) sec.style.display = 'none';
+  if (lastData) render(lastData);
 }
 
 function _togglePanel(panelId) {
@@ -1420,11 +1491,13 @@ function render(d) {
       const timeLabel = isTrackPB ? lap.lap_time + ' 🏆'
                       : isBest    ? lap.lap_time + ' ★'
                       : lap.lap_time;
+      const isSelected = _selectedSessionLap === lap.lap_num;
       const rowClass = [
         isBest ? 'best-lap' : '', isTrackPB ? 'track-pb-lap' : '',
-        isInvalid ? 'invalid' : '', isCompA ? 'comp-a-row' : '', isCompB ? 'comp-b-row' : ''
+        isInvalid ? 'invalid' : '', isCompA ? 'comp-a-row' : '', isCompB ? 'comp-b-row' : '',
+        isSelected ? 'lap-selected' : '',
       ].join(' ');
-      rows += `<tr class="${rowClass}">
+      rows += `<tr class="${rowClass}" onclick="if(event.target.tagName!=='BUTTON')selectSessionLap(${lap.lap_num})">
         <td class="lap-num">${lap.lap_num}</td>
         <td>${compoundPill(lap.compound)}</td>
         <td class="lap-time ${isTrackPB || isBest ? 'best' : ''}">${timeLabel}</td>
@@ -1474,7 +1547,16 @@ function msToLap(ms) {
 
 const _SECTOR_PALETTE = ['#e10600', '#f7c948', '#9b59b6'];
 
-function renderTelemetry(traceA, traceB = null) {
+function renderTelemetry(traceA, traceB = null, sfx = '') {
+  if (sfx) {
+    // Session-review mode: draw into -sr canvases
+    _renderSpeedChart(traceA, null, sfx);
+    _renderInputsChart(traceA, null, sfx);
+    _renderGearChart(traceA, null, sfx);
+    _renderSteerChart(traceA, null, sfx);
+    _renderGForceChart(traceA, null, sfx);
+    return;
+  }
   const sec = document.getElementById('telemetry-section');
   const waiting = document.getElementById('race-waiting');
   if (!traceA || traceA.length < 2) {
@@ -1502,8 +1584,8 @@ function renderTelemetry(traceA, traceB = null) {
 function _chartPad() { return { t: 6, b: 14, l: 28, r: 4 }; }
 
 
-function _renderSpeedChart(traceA, traceB = null) {
-  const canvas = document.getElementById('speed-canvas');
+function _renderSpeedChart(traceA, traceB = null, sfx = '') {
+  const canvas = document.getElementById('speed-canvas' + sfx);
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const w = canvas.width, h = canvas.height;
@@ -1616,8 +1698,8 @@ function _drawInputLines(ctx, trace, pad, cw, ch, thrColor, thrFill, brkColor, b
   ctx.stroke();
 }
 
-function _renderInputsChart(traceA, traceB = null) {
-  const canvas = document.getElementById('inputs-canvas');
+function _renderInputsChart(traceA, traceB = null, sfx = '') {
+  const canvas = document.getElementById('inputs-canvas' + sfx);
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const w = canvas.width, h = canvas.height;
@@ -1648,11 +1730,11 @@ function _renderInputsChart(traceA, traceB = null) {
     '#e10600', 'rgba(225,6,0,0.22)');
 }
 
-function _renderGForceChart(traceA, traceB = null) {
-  return _renderGForceChartImpl(traceA, traceB);
+function _renderGForceChart(traceA, traceB = null, sfx = '') {
+  return _renderGForceChartImpl(traceA, traceB, sfx);
 }
-function _renderGForceChartImpl(traceA, traceB) {
-  const canvas = document.getElementById('gforce-canvas');
+function _renderGForceChartImpl(traceA, traceB, sfx = '') {
+  const canvas = document.getElementById('gforce-canvas' + sfx);
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const w = canvas.width, h = canvas.height;
@@ -1728,8 +1810,8 @@ function _renderGForceChartImpl(traceA, traceB) {
 }
 
 // ── Gear chart ────────────────────────────────────────────────────────────────
-function _renderGearChart(traceA, traceB = null) {
-  const canvas = document.getElementById('gear-canvas');
+function _renderGearChart(traceA, traceB = null, sfx = '') {
+  const canvas = document.getElementById('gear-canvas' + sfx);
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const w = canvas.width, h = canvas.height;
@@ -1790,8 +1872,8 @@ function _renderGearChart(traceA, traceB = null) {
 }
 
 // ── Steering chart ─────────────────────────────────────────────────────────────
-function _renderSteerChart(traceA, traceB = null) {
-  const canvas = document.getElementById('steer-canvas');
+function _renderSteerChart(traceA, traceB = null, sfx = '') {
+  const canvas = document.getElementById('steer-canvas' + sfx);
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
   const w = canvas.width, h = canvas.height;


### PR DESCRIPTION
## Summary

- Click any lap row in the SESSION tab to load that lap's full telemetry (speed, throttle & brake, gear, steering, G-force) inline below the table; click the same row again or press ✕ CLOSE to dismiss
- Selected lap row is highlighted with a full-row tint via the `lap-selected` CSS class
- Refactored all five chart render functions to accept a canvas suffix parameter, so the same drawing code serves both the RACE tab and the new SESSION review panel without duplication

## Additional changes

- **README**: Added interactive lap review to the features list and a new "Inline lap telemetry review" subsection under SESSION tab docs
- **Landing page**: Removed the Team themes feature card

## Test plan

- [ ] Open the SESSION tab and click a lap row — telemetry panel should appear below the table with the correct lap's data
- [ ] Selected row should be highlighted (subtle white tint)
- [ ] Click the same row again — panel should dismiss and highlight clears
- [ ] Click ✕ CLOSE — same as above
- [ ] Confirm RACE tab telemetry still renders correctly (no regression from sfx refactor)
- [ ] Confirm A/B comparison overlay still works in the RACE tab

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg