### PR TITLE
Shrink charts, improve tyre wear layout and car SVG, brighten muted text

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -17,7 +17,7 @@
     --panel: #111114;
     --border: #222228;
     --text: #e8e8e8;
-    --muted: #666;
+    --muted: #999;
     --gold: #ffd700;
     --green: #00d68f;
     --purple: #c77dff;
@@ -550,7 +550,7 @@ backdrop-filter: blur(4px);
           </div>
           <div style="flex:1;">
             <div class="telem-label" style="margin-bottom:6px;">RPM</div>
-            <canvas id="rev-lights-canvas" width="600" height="28" style="width:100%;display:block;border-radius:4px;"></canvas>
+            <canvas id="rev-lights-canvas" width="600" height="20" style="width:100%;display:block;border-radius:4px;"></canvas>
           </div>
         </div>
       </div>
@@ -560,17 +560,18 @@ backdrop-filter: blur(4px);
           <div class="telem-wrap">
             <div class="telem-charts">
               <div class="telem-label">SPEED (km/h)</div>
-              <canvas id="speed-canvas" width="600" height="140" style="width:100%;display:block;"></canvas>
-              <div class="telem-label" style="margin-top:10px;">THROTTLE &amp; BRAKE</div>
-              <canvas id="inputs-canvas" width="600" height="100" style="width:100%;display:block;"></canvas>
-              <div class="telem-label" style="margin-top:10px;">GEAR</div>
-              <canvas id="gear-canvas" width="600" height="60" style="width:100%;display:block;"></canvas>
-              <div class="telem-label" style="margin-top:10px;">STEERING</div>
-              <canvas id="steer-canvas" width="600" height="70" style="width:100%;display:block;"></canvas>
+              <canvas id="speed-canvas" width="600" height="110" style="width:100%;display:block;"></canvas>
+              <div class="telem-label" style="margin-top:8px;">THROTTLE &amp; BRAKE</div>
+              <canvas id="inputs-canvas" width="600" height="80" style="width:100%;display:block;"></canvas>
+              <div class="telem-label" style="margin-top:8px;">GEAR</div>
+              <canvas id="gear-canvas" width="600" height="48" style="width:100%;display:block;"></canvas>
+              <div class="telem-label" style="margin-top:8px;">STEERING</div>
+              <canvas id="steer-canvas" width="600" height="55" style="width:100%;display:block;"></canvas>
             </div>
             <div class="telem-gforce-wrap">
               <div class="telem-label">G-FORCE</div>
-              <canvas id="gforce-canvas" width="220" height="220" style="display:block;width:100%;"></canvas>
+              <canvas id="gforce-canvas" width="220" height="180" style="display:block;width:100%;"></canvas>
+              <div id="tyre-wear-slot"></div>
             </div>
           </div>
         </div>
@@ -598,13 +599,13 @@ backdrop-filter: blur(4px);
         <div id="session-review-charts" class="telem-wrap" style="display:none;">
           <div class="telem-charts">
             <div class="telem-label">SPEED (km/h)</div>
-            <canvas id="speed-canvas-sr" width="600" height="140" style="width:100%;display:block;"></canvas>
-            <div class="telem-label" style="margin-top:10px;">THROTTLE &amp; BRAKE</div>
-            <canvas id="inputs-canvas-sr" width="600" height="100" style="width:100%;display:block;"></canvas>
-            <div class="telem-label" style="margin-top:10px;">GEAR</div>
-            <canvas id="gear-canvas-sr" width="600" height="60" style="width:100%;display:block;"></canvas>
-            <div class="telem-label" style="margin-top:10px;">STEERING</div>
-            <canvas id="steer-canvas-sr" width="600" height="70" style="width:100%;display:block;"></canvas>
+            <canvas id="speed-canvas-sr" width="600" height="110" style="width:100%;display:block;"></canvas>
+            <div class="telem-label" style="margin-top:8px;">THROTTLE &amp; BRAKE</div>
+            <canvas id="inputs-canvas-sr" width="600" height="80" style="width:100%;display:block;"></canvas>
+            <div class="telem-label" style="margin-top:8px;">GEAR</div>
+            <canvas id="gear-canvas-sr" width="600" height="48" style="width:100%;display:block;"></canvas>
+            <div class="telem-label" style="margin-top:8px;">STEERING</div>
+            <canvas id="steer-canvas-sr" width="600" height="55" style="width:100%;display:block;"></canvas>
           </div>
           <div class="telem-gforce-wrap">
             <div class="telem-label">G-FORCE</div>
@@ -1358,47 +1359,62 @@ function renderTyreDiagram(d) {
   const age = d.tyre_age_laps != null
     ? `<div style="text-align:center;font-size:.55rem;color:var(--muted);letter-spacing:.1em;margin-top:4px">${d.tyre_age_laps} LAP${d.tyre_age_laps !== 1 ? 'S' : ''} ON SET</div>`
     : '';
-  // Inline SVG top-down F1 car — tyres at all four corners
-  // Wider tyre blocks with bigger text for easy readability
-  const svg = `<svg viewBox="0 0 220 250" width="100%" style="display:block;max-width:280px;margin:0 auto">
-    <!-- rear wing -->
-    <rect x="22" y="210" width="176" height="10" rx="4" fill="rgba(255,255,255,.09)" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
-    <!-- rear diffuser -->
-    <rect x="54" y="200" width="112" height="12" rx="3" fill="rgba(255,255,255,.06)"/>
-    <!-- car body -->
-    <rect x="54" y="40" width="112" height="162" rx="14" fill="rgba(255,255,255,.08)" stroke="rgba(255,255,255,.18)" stroke-width="1.5"/>
-    <!-- sidepods -->
-    <rect x="40" y="88" width="26" height="68" rx="5" fill="rgba(255,255,255,.06)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
-    <rect x="154" y="88" width="26" height="68" rx="5" fill="rgba(255,255,255,.06)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
-    <!-- cockpit / halo -->
-    <ellipse cx="110" cy="128" rx="20" ry="34" fill="rgba(0,0,0,.6)" stroke="rgba(255,255,255,.12)" stroke-width="1"/>
-    <!-- front nose -->
-    <polygon points="74,40 146,40 134,16 86,16" fill="rgba(255,255,255,.07)" stroke="rgba(255,255,255,.15)" stroke-width="1"/>
-    <!-- front wing -->
-    <rect x="24" y="10" width="172" height="9" rx="4" fill="rgba(255,255,255,.09)" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
+  // Inline SVG top-down F1 car — front at top, rear at bottom
+  // Rear tyres wider than front; full wing elements for authenticity
+  const svg = `<svg viewBox="0 0 220 310" width="100%" style="display:block;max-width:200px;margin:0 auto">
+    <!-- FRONT WING end plates -->
+    <rect x="5"   y="0" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
+    <rect x="206" y="0" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
+    <!-- FRONT WING main plane -->
+    <rect x="14" y="7" width="192" height="8" rx="2" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.2)" stroke-width="1"/>
+    <rect x="22" y="13" width="176" height="4" rx="1" fill="rgba(255,255,255,.06)"/>
 
-    <!-- FL tyre -->
-    <rect x="2" y="32" width="36" height="68" rx="6" fill="${_twc(fl)}" stroke="rgba(255,255,255,.25)" stroke-width="1.5"/>
-    <text x="20" y="60" text-anchor="middle" dominant-baseline="middle" fill="${_twt(fl)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(fl)}</text>
-    <text x="20" y="91" text-anchor="middle" fill="rgba(255,255,255,.45)" font-size="9" font-family="monospace">FL</text>
+    <!-- NOSE CONE -->
+    <path d="M 91,22 L 129,22 L 120,52 L 100,52 Z" fill="rgba(255,255,255,.10)" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
 
-    <!-- FR tyre -->
-    <rect x="182" y="32" width="36" height="68" rx="6" fill="${_twc(fr)}" stroke="rgba(255,255,255,.25)" stroke-width="1.5"/>
-    <text x="200" y="60" text-anchor="middle" dominant-baseline="middle" fill="${_twt(fr)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(fr)}</text>
-    <text x="200" y="91" text-anchor="middle" fill="rgba(255,255,255,.45)" font-size="9" font-family="monospace">FR</text>
+    <!-- FRONT TYRES (narrower) -->
+    <rect x="13"  y="26" width="34" height="58" rx="8" fill="${_twc(fl)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
+    <text x="30"  y="51" text-anchor="middle" dominant-baseline="middle" fill="${_twt(fl)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(fl)}</text>
+    <text x="30"  y="76" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">FL</text>
+    <rect x="173" y="26" width="34" height="58" rx="8" fill="${_twc(fr)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
+    <text x="190" y="51" text-anchor="middle" dominant-baseline="middle" fill="${_twt(fr)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(fr)}</text>
+    <text x="190" y="76" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">FR</text>
 
-    <!-- RL tyre -->
-    <rect x="2" y="140" width="36" height="76" rx="6" fill="${_twc(rl)}" stroke="rgba(255,255,255,.25)" stroke-width="1.5"/>
-    <text x="20" y="172" text-anchor="middle" dominant-baseline="middle" fill="${_twt(rl)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(rl)}</text>
-    <text x="20" y="205" text-anchor="middle" fill="rgba(255,255,255,.45)" font-size="9" font-family="monospace">RL</text>
+    <!-- CAR BODY -->
+    <path d="M 84,22 C 68,35 58,56 55,80 L 53,112 L 53,152 C 53,167 56,180 63,192 L 67,212 L 70,242 L 76,262 L 90,268 L 130,268 L 144,262 L 150,242 L 153,212 L 157,192 C 164,180 167,167 167,152 L 167,112 L 165,80 C 162,56 152,35 136,22 Z"
+      fill="rgba(255,255,255,.08)" stroke="rgba(255,255,255,.17)" stroke-width="1.5"/>
 
-    <!-- RR tyre -->
-    <rect x="182" y="140" width="36" height="76" rx="6" fill="${_twc(rr)}" stroke="rgba(255,255,255,.25)" stroke-width="1.5"/>
-    <text x="200" y="172" text-anchor="middle" dominant-baseline="middle" fill="${_twt(rr)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(rr)}</text>
-    <text x="200" y="205" text-anchor="middle" fill="rgba(255,255,255,.45)" font-size="9" font-family="monospace">RR</text>
+    <!-- SIDEPODS -->
+    <rect x="46"  y="100" width="25" height="56" rx="6" fill="rgba(255,255,255,.05)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
+    <rect x="149" y="100" width="25" height="56" rx="6" fill="rgba(255,255,255,.05)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
+
+    <!-- COCKPIT / HALO -->
+    <ellipse cx="110" cy="128" rx="16" ry="29" fill="rgba(0,0,0,.55)" stroke="rgba(255,255,255,.12)" stroke-width="1"/>
+    <path d="M 97,109 Q 110,102 123,109" fill="none" stroke="rgba(255,255,255,.25)" stroke-width="2.5"/>
+
+    <!-- ENGINE COVER bump -->
+    <ellipse cx="110" cy="183" rx="19" ry="19" fill="rgba(255,255,255,.05)" stroke="rgba(255,255,255,.08)" stroke-width="1"/>
+
+    <!-- REAR TYRES (wider than front) -->
+    <rect x="10"  y="194" width="40" height="72" rx="9" fill="${_twc(rl)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
+    <text x="30"  y="226" text-anchor="middle" dominant-baseline="middle" fill="${_twt(rl)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(rl)}</text>
+    <text x="30"  y="257" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">RL</text>
+    <rect x="170" y="194" width="40" height="72" rx="9" fill="${_twc(rr)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
+    <text x="190" y="226" text-anchor="middle" dominant-baseline="middle" fill="${_twt(rr)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(rr)}</text>
+    <text x="190" y="257" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">RR</text>
+
+    <!-- REAR DIFFUSER -->
+    <rect x="70" y="263" width="80" height="13" rx="3" fill="rgba(255,255,255,.07)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
+
+    <!-- REAR WING end plates -->
+    <rect x="14"  y="277" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
+    <rect x="197" y="277" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
+    <!-- REAR WING main plane -->
+    <rect x="23"  y="281" width="174" height="8" rx="2" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.2)" stroke-width="1"/>
+    <rect x="30"  y="287" width="160" height="4" rx="1" fill="rgba(255,255,255,.06)"/>
   </svg>`;
-  return `<div class="panel">
-    <div class="panel-title">Tyre Wear</div>
+  return `<div style="margin-top:10px;">
+    <div class="telem-label">TYRE WEAR</div>
     <div class="tyre-svg-wrap">${svg}${age}</div>
   </div>`;
 }
@@ -1529,7 +1545,9 @@ function render(d) {
     </div>
   </div>`;
 
-  sidebar.innerHTML  = p1 + p2 + p3 + renderTyreDiagram(d);
+  sidebar.innerHTML  = p1 + p2 + p3;
+  const twSlot = document.getElementById('tyre-wear-slot');
+  if (twSlot) twSlot.innerHTML = renderTyreDiagram(d);
   lapTable.innerHTML = p4;
   _updateTrackSvg(d.track_svg || null);
 }


### PR DESCRIPTION
## Summary

- Reduce telemetry canvas heights to eliminate the need to scroll on the RACE tab (speed 140→110, inputs 100→80, gear 60→48, steering 70→55, G-force 220→180)
- Slim the rev-lights bar from 28 px to 20 px
- Move the tyre wear diagram from the sidebar to below the G-force circle in the RACE tab right column
- Redesign the car SVG with proper F1 top-down proportions: pointed nose cone, front/rear wing end plates with flap layers, sidepods, halo arch, engine cover bump, and wider rear tyres vs front
- Raise `--muted` colour from `#666` to `#999` for better legibility throughout the dashboard

## Test plan

- [ ] RACE tab fits on screen without scrolling after telemetry is live
- [ ] Rev-lights bar still renders correctly at reduced height
- [ ] Tyre wear diagram appears below the G-force circle (not in sidebar) when wear data is available
- [ ] Car SVG renders cleanly with all four tyre percentage labels visible
- [ ] Muted labels (sector headers, sub-labels, status text) are visibly brighter and easier to read

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg