### PR TITLE
UI polish, tyre status diagram, AI debrief improvements

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -108,9 +108,10 @@ state = {
     "race_result": None,               # populated when Final Classification packet (ID 8) arrives
     "player_fastest_lap": False,       # set True when FTLP event fires for the player
     "race_result_saved_sid": None,     # session ID for which race result was already saved
-    "tyre_wear":     [None, None, None, None],  # [RL, RR, FL, FR] float % from Car Damage packet
-    "tyre_damage":   [None, None, None, None],  # [RL, RR, FL, FR] uint8 % structural damage
-    "tyre_age_laps": None,                      # laps on current tyre set (from Car Status)
+    "tyre_wear":         [None, None, None, None],  # [RL, RR, FL, FR] float % from Car Damage packet
+    "tyre_damage":       [None, None, None, None],  # [RL, RR, FL, FR] uint8 % structural damage
+    "front_wing_damage": [None, None],              # [left, right] uint8 % front wing damage
+    "tyre_age_laps":     None,                      # laps on current tyre set (from Car Status)
 }
 
 TRACK_IDS = {
@@ -805,15 +806,20 @@ def parse_car_damage_packet(data, player_idx):
         base = HEADER_SIZE + player_idx * per_car
         if len(data) < base + 20:
             return
-        # +0  tyresWear[4]   4 × float  (RL, RR, FL, FR)
-        # +16 tyresDamage[4] 4 × uint8  (RL, RR, FL, FR)
+        # +0  tyresWear[4]        4 × float  (RL, RR, FL, FR)
+        # +16 tyresDamage[4]     4 × uint8  (RL, RR, FL, FR)
+        # +24 frontLeftWingDamage  uint8
+        # +25 frontRightWingDamage uint8
         wear   = struct.unpack_from("<4f", data, base +  0)
         damage = struct.unpack_from("<4B", data, base + 16)
-        # Clamp to valid range; reject obviously wrong values from bad offsets
-        valid = [round(w, 1) if 0.0 <= w <= 100.0 else None for w in wear]
+        valid  = [round(w, 1) if 0.0 <= w <= 100.0 else None for w in wear]
+        fw_dmg = [None, None]
+        if len(data) >= base + 26:
+            fw_dmg = list(struct.unpack_from("<2B", data, base + 24))
         with state_lock:
-            state["tyre_wear"]   = valid
-            state["tyre_damage"] = list(damage)
+            state["tyre_wear"]          = valid
+            state["tyre_damage"]        = list(damage)
+            state["front_wing_damage"]  = fw_dmg  # [left, right] 0-100
     except Exception as e:
         log.debug("parse_car_damage: %s", e)
 

--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -655,13 +655,15 @@ def parse_lap_data_packet(data, player_idx):
         # Compute aggregate telemetry stats from the trace and store in lap record
         if saved_trace:
             n = len(saved_trace)
-            max_spd  = max(p["speed"]              for p in saved_trace)
-            avg_spd  = sum(p["speed"]              for p in saved_trace) / n
-            avg_thr  = sum(p["throttle"]           for p in saved_trace) / n * 100
-            ft_pct   = sum(1 for p in saved_trace if p["throttle"] >= 0.95) / n * 100
-            avg_brk  = sum(p["brake"]              for p in saved_trace) / n * 100
-            hb_pct   = sum(1 for p in saved_trace if p["brake"] >= 0.5)  / n * 100
-            max_g    = max(abs(p.get("gLat", 0))   for p in saved_trace)
+            max_spd   = max(p["speed"]                    for p in saved_trace)
+            avg_spd   = sum(p["speed"]                    for p in saved_trace) / n
+            avg_thr   = sum(p["throttle"]                 for p in saved_trace) / n * 100
+            ft_pct    = sum(1 for p in saved_trace if p["throttle"] >= 0.95) / n * 100
+            avg_brk   = sum(p["brake"]                    for p in saved_trace) / n * 100
+            hb_pct    = sum(1 for p in saved_trace if p["brake"] >= 0.5)  / n * 100
+            max_g     = max(abs(p.get("gLat", 0))         for p in saved_trace)
+            avg_gear  = sum(p.get("gear", 0)              for p in saved_trace) / n
+            max_steer = max(abs(p.get("steer", 0))        for p in saved_trace)
             lap_record["telem"] = {
                 "max_speed":         round(max_spd),
                 "avg_speed":         round(avg_spd),
@@ -670,7 +672,16 @@ def parse_lap_data_packet(data, player_idx):
                 "avg_brake":         round(avg_brk),
                 "heavy_brake_pct":   round(hb_pct),
                 "max_g_lat":         round(max_g, 2),
+                "avg_gear":          round(avg_gear, 1),
+                "max_steer":         round(max_steer, 2),
             }
+            # Capture tyre wear at lap completion (FL, FR, RL, RR)
+            tw = state.get("tyre_wear", [None, None, None, None])
+            if any(v is not None for v in tw):
+                lap_record["telem"]["tyre_wear_fl"] = round(tw[2]) if tw[2] is not None else None
+                lap_record["telem"]["tyre_wear_fr"] = round(tw[3]) if tw[3] is not None else None
+                lap_record["telem"]["tyre_wear_rl"] = round(tw[0]) if tw[0] is not None else None
+                lap_record["telem"]["tyre_wear_rr"] = round(tw[1]) if tw[1] is not None else None
 
         if save_session_id is not None:
             db_save_lap(save_session_id, lap_record, trace=saved_trace)

--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -409,45 +409,55 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
     # Build telemetry table if any laps have telem data
     telem_laps = [lap for lap in laps if lap.get("telem")]
     telem_section = ""
+    has_tyre_wear = any(lap.get("telem", {}).get("tyre_wear_fl") is not None for lap in telem_laps)
     if telem_laps:
-        th = "Lap | MaxSpd | AvgSpd | AvgThr% | FullThr% | AvgBrk% | HvyBrk% | MaxGLat"
+        th = "Lap | MaxSpd | AvgSpd | FullThr% | HvyBrk% | MaxGLat | AvgGear | MaxSteer"
+        if has_tyre_wear:
+            th += " | FL% | FR% | RL% | RR%"
         trows = []
         for lap in telem_laps:
             t = lap["telem"]
-            trows.append(
+            row = (
                 f"Lap {lap.get('lap_num', '?'):>3} | "
                 f"{t.get('max_speed', '—'):>6} | "
                 f"{t.get('avg_speed', '—'):>6} | "
-                f"{t.get('avg_throttle', '—'):>7} | "
                 f"{t.get('full_throttle_pct', '—'):>8} | "
-                f"{t.get('avg_brake', '—'):>7} | "
                 f"{t.get('heavy_brake_pct', '—'):>7} | "
-                f"{t.get('max_g_lat', '—'):>7}"
+                f"{t.get('max_g_lat', '—'):>7} | "
+                f"{t.get('avg_gear', '—'):>7} | "
+                f"{t.get('max_steer', '—'):>8}"
             )
+            if has_tyre_wear:
+                row += (
+                    f" | {t.get('tyre_wear_fl', '—'):>3}"
+                    f" | {t.get('tyre_wear_fr', '—'):>3}"
+                    f" | {t.get('tyre_wear_rl', '—'):>3}"
+                    f" | {t.get('tyre_wear_rr', '—'):>3}"
+                )
+            trows.append(row)
         telem_section = (
-            "\n\nTelemetry data (speed km/h, throttle/brake as %, G-force):\n"
+            "\n\nTelemetry (speed km/h, throttle/brake %, G-force, steer 0–1 scale, tyre wear %):\n"
             f"{th}\n" + "\n".join(trows)
         )
 
     has_telem = bool(telem_laps)
-    telem_instruction = (
-        " Where telemetry data is available, reference it specifically — "
-        "comment on top speed, throttle application (full-throttle %), "
-        "braking commitment (heavy-brake %), and peak lateral G as indicators of "
-        "driving style and corner technique. Cross-reference with sector times to "
-        "pinpoint where time is being lost."
+    telem_note = (
+        " Use the telemetry to go beyond lap times — call out where full-throttle percentage "
+        "or heavy braking suggests time is being left on the table, and whether tyre wear "
+        "patterns point to an underlying setup or driving style issue."
         if has_telem else ""
     )
 
     prompt = (
-        "You are a Formula 1 race engineer giving a post-session debrief to a sim racing driver.\n"
-        "Analyse the lap and telemetry data below and give a concise, insightful debrief (3–5 short paragraphs).\n"
-        "Cover: pace consistency, sector weaknesses, tyre compound performance, best lap analysis, "
-        f"and one actionable recommendation for the next session.{telem_instruction}\n"
-        "Use F1 engineering language. Be direct. Interpret the numbers — do not just repeat them.\n\n"
+        "You are a blunt, plain-speaking F1 race engineer debriefing a sim driver. "
+        "Write 2–3 short paragraphs — no bullet points, no sub-headings, no filler opener. "
+        "Talk like you're standing next to the driver in the garage: direct, specific, and honest. "
+        "Pick out what actually matters: is the pace consistent or scattered, where are sectors "
+        "being lost, how are the tyres behaving across the stint, and what is the one thing to "
+        f"address before the next session.{telem_note} "
+        "Interpret the numbers — don't recite them. Keep the whole debrief under 180 words.\n\n"
         f"Session: {track} — {sess_type} — {weather}\n"
-        f"Session Best: {best_time}\n"
-        f"Track PB: {pb_time}{pb_suffix}\n"
+        f"Session best: {best_time}   Track PB: {pb_time}{pb_suffix}\n"
         f"Total laps: {len(laps)}\n\n"
         f"Lap data:\n{header}\n" + "\n".join(rows) + telem_section
     )
@@ -463,8 +473,8 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
     aoai_url     = f"{endpoint}/openai/deployments/{deployment}/chat/completions?api-version=2024-02-01"
     aoai_payload = json.dumps({
         "messages": [{"role": "user", "content": prompt}],
-        "max_tokens": 800,
-        "temperature": 0.7,
+        "max_tokens": 500,
+        "temperature": 0.75,
     }).encode()
 
     aoai_req = _urllib.Request(

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1358,16 +1358,23 @@ function _twt(w) {  // tyre text colour (unused but kept for compat)
 }
 
 function renderTyreDiagram(d) {
-  const wear   = d.tyre_wear   || [null, null, null, null]; // [RL, RR, FL, FR]
-  const damage = d.tyre_damage || [null, null, null, null]; // [RL, RR, FL, FR]
+  const wear   = d.tyre_wear         || [null, null, null, null]; // [RL, RR, FL, FR]
+  const damage = d.tyre_damage       || [null, null, null, null]; // [RL, RR, FL, FR]
+  const fwd    = d.front_wing_damage || [null, null];             // [left, right]
   if (wear.every(v => v === null) && damage.every(v => v === null)) return '';
   const fl = wear[2],   fr = wear[3],   rl = wear[0],   rr = wear[1];
-  const dfl = damage[2], dfr = damage[3], drl = damage[0], drr = damage[1];
-  const hasDamage = damage.some(v => v !== null && v >= 10);
+  const dfl = damage[2] || 0, dfr = damage[3] || 0, drl = damage[0] || 0, drr = damage[1] || 0;
+  const fwL = fwd[0] || 0, fwR = fwd[1] || 0;
+  const hasDamage = [dfl,dfr,drl,drr,fwL,fwR].some(v => v >= 10);
+  // Damage overlay: semi-transparent red fill, opacity = damage/100 * 0.65
+  const dmgFill = v => `rgba(225,6,0,${Math.min(v / 100 * 0.70, 0.70).toFixed(2)})`;
+  // Front wing panel fill: blend damage red into the base panel colour
+  const wingFill = v => v >= 10
+    ? `rgba(225,6,0,${Math.min(v / 100 * 0.55, 0.55).toFixed(2)})`
+    : 'rgba(255,255,255,.11)';
   const age = d.tyre_age_laps != null
     ? `<div style="text-align:center;font-size:.55rem;color:var(--muted);letter-spacing:.1em;margin-top:2px">${d.tyre_age_laps} LAP${d.tyre_age_laps !== 1 ? 'S' : ''} ON SET</div>`
     : '';
-  // Legend: wear swatches + damage indicator if relevant
   const legend = `<div style="display:flex;align-items:center;justify-content:center;gap:5px;margin-top:5px;flex-wrap:wrap;">
     <span style="font-size:.5rem;color:var(--muted);letter-spacing:.05em;">WEAR</span>
     <span style="display:inline-flex;gap:2px;">
@@ -1376,8 +1383,7 @@ function renderTyreDiagram(d) {
       <span style="width:8px;height:8px;background:#ff8c00;border-radius:2px;display:inline-block;"></span>
       <span style="width:8px;height:8px;background:#e10600;border-radius:2px;display:inline-block;"></span>
     </span>
-    ${hasDamage ? `<span style="font-size:.5rem;color:var(--muted);letter-spacing:.05em;margin-left:4px;">DAMAGE</span>
-    <span style="width:10px;height:10px;border:2px solid #e10600;border-radius:2px;display:inline-block;"></span>` : ''}
+    ${hasDamage ? `<span style="font-size:.5rem;color:#e10600;letter-spacing:.05em;margin-left:6px;">▲ DAMAGE</span>` : ''}
   </div>`;
   const svg = `<svg viewBox="0 0 220 330" width="100%" style="display:block;max-width:200px;margin:0 auto">
 
@@ -1385,9 +1391,9 @@ function renderTyreDiagram(d) {
     <!-- Endplates -->
     <rect x="9"   y="2"  width="8"  height="20" rx="2" fill="rgba(255,255,255,.15)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
     <rect x="203" y="2"  width="8"  height="20" rx="2" fill="rgba(255,255,255,.15)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
-    <!-- Main plane (angled panels either side of nose strut) -->
-    <path d="M 17,16 L 100,26 L 100,20 L 17,8 Z"  fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
-    <path d="M 203,16 L 120,26 L 120,20 L 203,8 Z" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
+    <!-- Main plane (angled panels — tinted red when damaged) -->
+    <path d="M 17,16 L 100,26 L 100,20 L 17,8 Z"  fill="${wingFill(fwL)}" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
+    <path d="M 203,16 L 120,26 L 120,20 L 203,8 Z" fill="${wingFill(fwR)}" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
     <!-- Flap detail lines -->
     <line x1="18"  y1="19" x2="99"  y2="24" stroke="rgba(255,255,255,.07)" stroke-width="1"/>
     <line x1="202" y1="19" x2="121" y2="24" stroke="rgba(255,255,255,.07)" stroke-width="1"/>
@@ -1407,10 +1413,12 @@ function renderTyreDiagram(d) {
     <line x1="173" y1="86" x2="115" y2="74" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
     <rect x="170"  y="73" width="8"  height="16" rx="1" fill="rgba(255,255,255,.09)" stroke="rgba(255,255,255,.14)" stroke-width="1"/>
 
-    <!-- ═══ FRONT TYRES ═══  fill=wear  stroke=damage -->
-    <rect x="13"  y="64" width="32" height="56" rx="8" fill="${_twc(fl)}" stroke="${_tdc(dfl)}" stroke-width="2.5"/>
+    <!-- ═══ FRONT TYRES ═══  base=wear fill, overlay=damage fill -->
+    <rect x="13"  y="64" width="32" height="56" rx="8" fill="${_twc(fl)}" stroke="rgba(255,255,255,.18)" stroke-width="1.5"/>
+    ${dfl >= 5 ? `<rect x="13" y="64" width="32" height="56" rx="8" fill="${dmgFill(dfl)}"/>` : ''}
     <circle cx="29"  cy="92" r="4" fill="rgba(0,0,0,.35)"/>
-    <rect x="175" y="64" width="32" height="56" rx="8" fill="${_twc(fr)}" stroke="${_tdc(dfr)}" stroke-width="2.5"/>
+    <rect x="175" y="64" width="32" height="56" rx="8" fill="${_twc(fr)}" stroke="rgba(255,255,255,.18)" stroke-width="1.5"/>
+    ${dfr >= 5 ? `<rect x="175" y="64" width="32" height="56" rx="8" fill="${dmgFill(dfr)}"/>` : ''}
     <circle cx="191" cy="92" r="4" fill="rgba(0,0,0,.35)"/>
 
     <!-- ═══ MAIN BODY ═══ -->
@@ -1454,9 +1462,11 @@ function renderTyreDiagram(d) {
     <line x1="169" y1="262" x2="147" y2="258" stroke="rgba(255,255,255,.14)" stroke-width="1.2"/>
 
     <!-- ═══ REAR TYRES (wider than front) ═══ -->
-    <rect x="9"   y="236" width="40" height="70" rx="9" fill="${_twc(rl)}" stroke="${_tdc(drl)}" stroke-width="2.5"/>
+    <rect x="9"   y="236" width="40" height="70" rx="9" fill="${_twc(rl)}" stroke="rgba(255,255,255,.18)" stroke-width="1.5"/>
+    ${drl >= 5 ? `<rect x="9" y="236" width="40" height="70" rx="9" fill="${dmgFill(drl)}"/>` : ''}
     <circle cx="29"  cy="271" r="5" fill="rgba(0,0,0,.35)"/>
-    <rect x="171" y="236" width="40" height="70" rx="9" fill="${_twc(rr)}" stroke="${_tdc(drr)}" stroke-width="2.5"/>
+    <rect x="171" y="236" width="40" height="70" rx="9" fill="${_twc(rr)}" stroke="rgba(255,255,255,.18)" stroke-width="1.5"/>
+    ${drr >= 5 ? `<rect x="171" y="236" width="40" height="70" rx="9" fill="${dmgFill(drr)}"/>` : ''}
     <circle cx="191" cy="271" r="5" fill="rgba(0,0,0,.35)"/>
 
     <!-- ═══ REAR DIFFUSER ═══ -->

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1338,84 +1338,140 @@ function compoundPill(c) {
   return `<span class="cpill cpill-${abbr}">${abbr}</span>`;
 }
 
-// ── Tyre wear diagram ─────────────────────────────────────────────────────────
-function _twc(w) {  // tyre wear colour
-  if (w === null || w === undefined) return '#1e1e1e';
+// ── Tyre wear / damage diagram ─────────────────────────────────────────────────
+function _twc(w) {  // tyre wear fill colour
+  if (w === null || w === undefined) return 'rgba(255,255,255,.06)';
   if (w < 25) return '#00d68f';
   if (w < 50) return '#ffd700';
   if (w < 75) return '#ff8c00';
   return '#e10600';
 }
-function _twt(w) {  // tyre text colour
+function _tdc(d) {  // tyre damage border colour
+  if (d === null || d === undefined || d < 10) return 'rgba(255,255,255,.22)';
+  if (d < 30) return '#ffd700';
+  if (d < 60) return '#ff8c00';
+  return '#e10600';
+}
+function _twt(w) {  // tyre text colour (unused but kept for compat)
   if (w === null || w === undefined) return '#444';
   return w < 50 ? '#000' : '#fff';
 }
 
 function renderTyreDiagram(d) {
-  const wear = d.tyre_wear || [null, null, null, null]; // [RL, RR, FL, FR]
-  if (wear.every(v => v === null)) return '';
-  const fl = wear[2], fr = wear[3], rl = wear[0], rr = wear[1];
-  const pct = v => v !== null ? Math.round(v) + '%' : '—';
+  const wear   = d.tyre_wear   || [null, null, null, null]; // [RL, RR, FL, FR]
+  const damage = d.tyre_damage || [null, null, null, null]; // [RL, RR, FL, FR]
+  if (wear.every(v => v === null) && damage.every(v => v === null)) return '';
+  const fl = wear[2],   fr = wear[3],   rl = wear[0],   rr = wear[1];
+  const dfl = damage[2], dfr = damage[3], drl = damage[0], drr = damage[1];
+  const hasDamage = damage.some(v => v !== null && v >= 10);
   const age = d.tyre_age_laps != null
-    ? `<div style="text-align:center;font-size:.55rem;color:var(--muted);letter-spacing:.1em;margin-top:4px">${d.tyre_age_laps} LAP${d.tyre_age_laps !== 1 ? 'S' : ''} ON SET</div>`
+    ? `<div style="text-align:center;font-size:.55rem;color:var(--muted);letter-spacing:.1em;margin-top:2px">${d.tyre_age_laps} LAP${d.tyre_age_laps !== 1 ? 'S' : ''} ON SET</div>`
     : '';
-  // Inline SVG top-down F1 car — front at top, rear at bottom
-  // Rear tyres wider than front; full wing elements for authenticity
-  const svg = `<svg viewBox="0 0 220 310" width="100%" style="display:block;max-width:200px;margin:0 auto">
-    <!-- FRONT WING end plates -->
-    <rect x="5"   y="0" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
-    <rect x="206" y="0" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
-    <!-- FRONT WING main plane -->
-    <rect x="14" y="7" width="192" height="8" rx="2" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.2)" stroke-width="1"/>
-    <rect x="22" y="13" width="176" height="4" rx="1" fill="rgba(255,255,255,.06)"/>
+  // Legend: wear swatches + damage indicator if relevant
+  const legend = `<div style="display:flex;align-items:center;justify-content:center;gap:5px;margin-top:5px;flex-wrap:wrap;">
+    <span style="font-size:.5rem;color:var(--muted);letter-spacing:.05em;">WEAR</span>
+    <span style="display:inline-flex;gap:2px;">
+      <span style="width:8px;height:8px;background:#00d68f;border-radius:2px;display:inline-block;"></span>
+      <span style="width:8px;height:8px;background:#ffd700;border-radius:2px;display:inline-block;"></span>
+      <span style="width:8px;height:8px;background:#ff8c00;border-radius:2px;display:inline-block;"></span>
+      <span style="width:8px;height:8px;background:#e10600;border-radius:2px;display:inline-block;"></span>
+    </span>
+    ${hasDamage ? `<span style="font-size:.5rem;color:var(--muted);letter-spacing:.05em;margin-left:4px;">DAMAGE</span>
+    <span style="width:10px;height:10px;border:2px solid #e10600;border-radius:2px;display:inline-block;"></span>` : ''}
+  </div>`;
+  const svg = `<svg viewBox="0 0 220 330" width="100%" style="display:block;max-width:200px;margin:0 auto">
 
-    <!-- NOSE CONE -->
-    <path d="M 91,22 L 129,22 L 120,52 L 100,52 Z" fill="rgba(255,255,255,.10)" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
+    <!-- ═══ FRONT WING ═══ -->
+    <!-- Endplates -->
+    <rect x="9"   y="2"  width="8"  height="20" rx="2" fill="rgba(255,255,255,.15)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
+    <rect x="203" y="2"  width="8"  height="20" rx="2" fill="rgba(255,255,255,.15)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
+    <!-- Main plane (angled panels either side of nose strut) -->
+    <path d="M 17,16 L 100,26 L 100,20 L 17,8 Z"  fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
+    <path d="M 203,16 L 120,26 L 120,20 L 203,8 Z" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.18)" stroke-width="1"/>
+    <!-- Flap detail lines -->
+    <line x1="18"  y1="19" x2="99"  y2="24" stroke="rgba(255,255,255,.07)" stroke-width="1"/>
+    <line x1="202" y1="19" x2="121" y2="24" stroke="rgba(255,255,255,.07)" stroke-width="1"/>
+    <!-- Camera pod / T-cam strut -->
+    <rect x="106" y="4"  width="8"  height="24" rx="2" fill="rgba(255,255,255,.16)" stroke="rgba(255,255,255,.2)" stroke-width="1"/>
 
-    <!-- FRONT TYRES (narrower) -->
-    <rect x="13"  y="26" width="34" height="58" rx="8" fill="${_twc(fl)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
-    <text x="30"  y="51" text-anchor="middle" dominant-baseline="middle" fill="${_twt(fl)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(fl)}</text>
-    <text x="30"  y="76" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">FL</text>
-    <rect x="173" y="26" width="34" height="58" rx="8" fill="${_twc(fr)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
-    <text x="190" y="51" text-anchor="middle" dominant-baseline="middle" fill="${_twt(fr)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(fr)}</text>
-    <text x="190" y="76" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">FR</text>
+    <!-- ═══ NOSE CONE ═══ -->
+    <path d="M 98,26 L 122,26 L 115,62 L 105,62 Z" fill="rgba(255,255,255,.10)" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
 
-    <!-- CAR BODY -->
-    <path d="M 84,22 C 68,35 58,56 55,80 L 53,112 L 53,152 C 53,167 56,180 63,192 L 67,212 L 70,242 L 76,262 L 90,268 L 130,268 L 144,262 L 150,242 L 153,212 L 157,192 C 164,180 167,167 167,152 L 167,112 L 165,80 C 162,56 152,35 136,22 Z"
+    <!-- ═══ FRONT SUSPENSION WISHBONES ═══ -->
+    <!-- FL upper / lower arms + upright -->
+    <line x1="47" y1="76"  x2="105" y2="66" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
+    <line x1="47" y1="86"  x2="105" y2="74" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
+    <rect x="42"  y="73"  width="8"  height="16" rx="1" fill="rgba(255,255,255,.09)" stroke="rgba(255,255,255,.14)" stroke-width="1"/>
+    <!-- FR upper / lower arms + upright -->
+    <line x1="173" y1="76" x2="115" y2="66" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
+    <line x1="173" y1="86" x2="115" y2="74" stroke="rgba(255,255,255,.17)" stroke-width="1.2"/>
+    <rect x="170"  y="73" width="8"  height="16" rx="1" fill="rgba(255,255,255,.09)" stroke="rgba(255,255,255,.14)" stroke-width="1"/>
+
+    <!-- ═══ FRONT TYRES ═══  fill=wear  stroke=damage -->
+    <rect x="13"  y="64" width="32" height="56" rx="8" fill="${_twc(fl)}" stroke="${_tdc(dfl)}" stroke-width="2.5"/>
+    <circle cx="29"  cy="92" r="4" fill="rgba(0,0,0,.35)"/>
+    <rect x="175" y="64" width="32" height="56" rx="8" fill="${_twc(fr)}" stroke="${_tdc(dfr)}" stroke-width="2.5"/>
+    <circle cx="191" cy="92" r="4" fill="rgba(0,0,0,.35)"/>
+
+    <!-- ═══ MAIN BODY ═══ -->
+    <path d="M 99,62
+             C 86,70 72,86 64,106
+             L 56,132 L 53,158 L 53,178
+             C 53,194 57,210 64,222
+             L 68,242 L 70,264 L 75,280
+             L 90,286 L 130,286 L 145,280
+             L 150,264 L 152,242 L 156,222
+             C 163,210 167,194 167,178
+             L 167,158 L 164,132 L 156,106
+             C 148,86 134,70 121,62 Z"
       fill="rgba(255,255,255,.08)" stroke="rgba(255,255,255,.17)" stroke-width="1.5"/>
 
-    <!-- SIDEPODS -->
-    <rect x="46"  y="100" width="25" height="56" rx="6" fill="rgba(255,255,255,.05)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
-    <rect x="149" y="100" width="25" height="56" rx="6" fill="rgba(255,255,255,.05)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
+    <!-- Bargeboard / floor edges visible from above -->
+    <path d="M 56,134 L 46,142 L 46,172 L 56,180" fill="none" stroke="rgba(255,255,255,.08)" stroke-width="1.2"/>
+    <path d="M 164,134 L 174,142 L 174,172 L 164,180" fill="none" stroke="rgba(255,255,255,.08)" stroke-width="1.2"/>
 
-    <!-- COCKPIT / HALO -->
-    <ellipse cx="110" cy="128" rx="16" ry="29" fill="rgba(0,0,0,.55)" stroke="rgba(255,255,255,.12)" stroke-width="1"/>
-    <path d="M 97,109 Q 110,102 123,109" fill="none" stroke="rgba(255,255,255,.25)" stroke-width="2.5"/>
+    <!-- ═══ WING MIRRORS ═══ -->
+    <path d="M 68,132 L 59,126 L 57,134 L 68,140 Z" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.16)" stroke-width="1"/>
+    <path d="M 152,132 L 161,126 L 163,134 L 152,140 Z" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.16)" stroke-width="1"/>
 
-    <!-- ENGINE COVER bump -->
-    <ellipse cx="110" cy="183" rx="19" ry="19" fill="rgba(255,255,255,.05)" stroke="rgba(255,255,255,.08)" stroke-width="1"/>
+    <!-- ═══ COCKPIT / HALO ═══ -->
+    <ellipse cx="110" cy="146" rx="17" ry="28" fill="rgba(0,0,0,.65)" stroke="rgba(255,255,255,.13)" stroke-width="1"/>
+    <!-- Halo arch -->
+    <path d="M 96,127 Q 110,119 124,127" fill="none" stroke="rgba(255,255,255,.30)" stroke-width="2.5"/>
 
-    <!-- REAR TYRES (wider than front) -->
-    <rect x="10"  y="194" width="40" height="72" rx="9" fill="${_twc(rl)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
-    <text x="30"  y="226" text-anchor="middle" dominant-baseline="middle" fill="${_twt(rl)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(rl)}</text>
-    <text x="30"  y="257" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">RL</text>
-    <rect x="170" y="194" width="40" height="72" rx="9" fill="${_twc(rr)}" stroke="rgba(255,255,255,.28)" stroke-width="1.5"/>
-    <text x="190" y="226" text-anchor="middle" dominant-baseline="middle" fill="${_twt(rr)}" font-size="12" font-weight="700" font-family="'Share Tech Mono',monospace">${pct(rr)}</text>
-    <text x="190" y="257" text-anchor="middle" fill="rgba(255,255,255,.5)" font-size="9" font-family="monospace">RR</text>
+    <!-- ═══ ENGINE COVER / BODYWORK ═══ -->
+    <ellipse cx="110" cy="192" rx="20" ry="20" fill="rgba(255,255,255,.05)" stroke="rgba(255,255,255,.08)" stroke-width="1"/>
+    <!-- Centre spine -->
+    <line x1="110" y1="174" x2="110" y2="244" stroke="rgba(255,255,255,.06)" stroke-width="2"/>
+    <!-- T-tray panel detail -->
+    <path d="M 88,214 L 132,214 L 132,220 L 120,220 L 120,234 L 100,234 L 100,220 L 88,220 Z"
+      fill="rgba(255,255,255,.04)" stroke="rgba(255,255,255,.08)" stroke-width="1"/>
 
-    <!-- REAR DIFFUSER -->
-    <rect x="70" y="263" width="80" height="13" rx="3" fill="rgba(255,255,255,.07)" stroke="rgba(255,255,255,.1)" stroke-width="1"/>
+    <!-- ═══ REAR SUSPENSION WISHBONES ═══ -->
+    <line x1="51"  y1="252" x2="73"  y2="246" stroke="rgba(255,255,255,.14)" stroke-width="1.2"/>
+    <line x1="51"  y1="262" x2="73"  y2="258" stroke="rgba(255,255,255,.14)" stroke-width="1.2"/>
+    <line x1="169" y1="252" x2="147" y2="246" stroke="rgba(255,255,255,.14)" stroke-width="1.2"/>
+    <line x1="169" y1="262" x2="147" y2="258" stroke="rgba(255,255,255,.14)" stroke-width="1.2"/>
 
-    <!-- REAR WING end plates -->
-    <rect x="14"  y="277" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
-    <rect x="197" y="277" width="9" height="22" rx="3" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.22)" stroke-width="1"/>
-    <!-- REAR WING main plane -->
-    <rect x="23"  y="281" width="174" height="8" rx="2" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.2)" stroke-width="1"/>
-    <rect x="30"  y="287" width="160" height="4" rx="1" fill="rgba(255,255,255,.06)"/>
+    <!-- ═══ REAR TYRES (wider than front) ═══ -->
+    <rect x="9"   y="236" width="40" height="70" rx="9" fill="${_twc(rl)}" stroke="${_tdc(drl)}" stroke-width="2.5"/>
+    <circle cx="29"  cy="271" r="5" fill="rgba(0,0,0,.35)"/>
+    <rect x="171" y="236" width="40" height="70" rx="9" fill="${_twc(rr)}" stroke="${_tdc(drr)}" stroke-width="2.5"/>
+    <circle cx="191" cy="271" r="5" fill="rgba(0,0,0,.35)"/>
+
+    <!-- ═══ REAR DIFFUSER ═══ -->
+    <rect x="70"  y="280" width="80" height="12" rx="3" fill="rgba(255,255,255,.07)" stroke="rgba(255,255,255,.12)" stroke-width="1"/>
+    <rect x="86"  y="291" width="48" height="8"  rx="2" fill="rgba(255,255,255,.06)" stroke="rgba(255,255,255,.10)" stroke-width="1"/>
+
+    <!-- ═══ REAR WING ═══ -->
+    <rect x="14"  y="307" width="8"   height="20" rx="2" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.20)" stroke-width="1"/>
+    <rect x="198" y="307" width="8"   height="20" rx="2" fill="rgba(255,255,255,.14)" stroke="rgba(255,255,255,.20)" stroke-width="1"/>
+    <rect x="22"  y="311" width="176" height="8"  rx="2" fill="rgba(255,255,255,.11)" stroke="rgba(255,255,255,.20)" stroke-width="1"/>
+    <rect x="28"  y="317" width="164" height="4"  rx="1" fill="rgba(255,255,255,.06)"/>
   </svg>`;
   return `<div style="margin-top:10px;">
-    <div class="telem-label">TYRE WEAR</div>
-    <div class="tyre-svg-wrap">${svg}${age}</div>
+    <div class="telem-label">TYRE STATUS</div>
+    <div class="tyre-svg-wrap">${svg}${age}${legend}</div>
   </div>`;
 }
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -400,7 +400,7 @@ tr.comp-b-row td { background:rgba(247,164,76,.07); }
 .telem-wrap { display: flex; gap: 10px; align-items: flex-start; margin-top: 4px; }
 .telem-charts { flex: 1; min-width: 0; }
 .telem-gforce-wrap { width: 220px; flex-shrink: 0; }
-.telem-label { font-size: .72rem; letter-spacing: .1em; color: var(--muted); margin-bottom: 4px; }
+.telem-label { font-size: .72rem; letter-spacing: .1em; color: #bbb; margin-bottom: 4px; }
 
 /* Community leaderboard panel */
 .lb-wrap { padding-bottom: 8px; }
@@ -461,7 +461,7 @@ backdrop-filter: blur(4px);
 #track-canvas { border-radius:8px; background:transparent; }
 .map-mode-btn {
   font-size: .52rem; padding: 3px 8px; border-radius: 5px; cursor: pointer;
-  background: var(--glass); border: 1px solid var(--glass-border); color: var(--muted);
+  background: var(--glass); border: 1px solid var(--glass-border); color: #ccc;
   font-family: 'Share Tech Mono', monospace; letter-spacing: .06em;
   transition: border-color .2s, color .2s, background .2s;
 }
@@ -1624,7 +1624,7 @@ function _renderSpeedChart(traceA, traceB = null, sfx = '') {
     const y = pad.t + ch - ((v - minS) / rng) * ch;
     ctx.strokeStyle = 'rgba(255,255,255,0.06)';
     ctx.beginPath(); ctx.moveTo(pad.l, y); ctx.lineTo(w - pad.r, y); ctx.stroke();
-    ctx.fillStyle = 'rgba(255,255,255,0.28)'; ctx.font = '8px monospace';
+    ctx.fillStyle = 'rgba(255,255,255,0.60)'; ctx.font = '8px monospace';
     ctx.fillText(v, 0, y + 3);
   }
 
@@ -1769,7 +1769,7 @@ function _renderGForceChartImpl(traceA, traceB, sfx = '') {
     ctx.strokeStyle = g === 3 ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.08)';
     ctx.lineWidth = g === 3 ? 1.5 : 1;
     ctx.stroke();
-    ctx.fillStyle = 'rgba(255,255,255,0.25)'; ctx.font = '8px monospace';
+    ctx.fillStyle = 'rgba(255,255,255,0.55)'; ctx.font = '8px monospace';
     ctx.fillText(`${g}G`, cx + scale * g / maxG + 2, cy - 2);
   }
 
@@ -1779,7 +1779,7 @@ function _renderGForceChartImpl(traceA, traceB, sfx = '') {
   ctx.beginPath(); ctx.moveTo(4, cy); ctx.lineTo(w - 4, cy); ctx.stroke();
 
   // Axis labels
-  ctx.fillStyle = 'rgba(255,255,255,0.25)'; ctx.font = '7px monospace';
+  ctx.fillStyle = 'rgba(255,255,255,0.55)'; ctx.font = '7px monospace';
   ctx.fillText('LAT', w - 20, cy - 3);
   ctx.fillText('LON', cx + 3, 10);
 
@@ -1882,7 +1882,7 @@ function _renderGearChart(traceA, traceB = null, sfx = '') {
   drawGearTrace(traceA, 'rgba(225,6,0,0.12)', '#e10600');
 
   // Y-axis gear labels
-  ctx.fillStyle = 'rgba(255,255,255,0.28)'; ctx.font = '8px monospace';
+  ctx.fillStyle = 'rgba(255,255,255,0.60)'; ctx.font = '8px monospace';
   for (let g = 2; g <= MAX_GEAR; g += 2) {
     const y = pad.t + ch - (g / MAX_GEAR) * ch;
     ctx.fillText(g, 0, y + 3);
@@ -1920,7 +1920,7 @@ function _renderSteerChart(traceA, traceB = null, sfx = '') {
   ctx.beginPath(); ctx.moveTo(pad.l, cy); ctx.lineTo(pad.l + cw, cy); ctx.stroke();
 
   // Y-axis labels
-  ctx.fillStyle = 'rgba(255,255,255,0.28)'; ctx.font = '8px monospace';
+  ctx.fillStyle = 'rgba(255,255,255,0.60)'; ctx.font = '8px monospace';
   ctx.fillText('L', 0, pad.t + 9);
   ctx.fillText('R', 0, pad.t + ch);
 


### PR DESCRIPTION
## Summary

### Interactive lap review (SESSION tab)
- Click any lap row to load its full telemetry inline below the table (speed, throttle & brake, gear, steering, G-force)
- Selected row highlighted with a full-row tint; click again or press ✕ CLOSE to dismiss

### Chart & layout improvements
- Telemetry canvas heights reduced (speed 140→110, inputs 100→80, gear 60→48, steering 70→55, G-force 220→180) — everything fits without scrolling
- Rev-lights bar slimmed from 28 px to 20 px
- Tyre status diagram moved from the sidebar to below the G-force circle in the RACE tab right column

### Tyre status diagram — full redesign
- Detailed top-down F1 car SVG: front wing with angled panels + endplates + T-cam strut, nose cone, wishbones, wing mirrors, cockpit/halo, engine cover, T-tray floor panel, rear diffuser, rear wing
- Rear tyres wider than front tyres
- **Tyre fill** = wear level (green → yellow → orange → red); no percentage labels
- **Damage overlay** = red fill on top of wear colour, opacity scales with damage % — appears on each tyre independently
- **Front wing damage** — left and right panels tint red independently (parsed from packet ID 10 offsets +24/+25)
- `▲ DAMAGE` legend label shown in red only when damage is present
- Label updated from "Tyre Wear" to "Tyre Status"

### Readability
- `--muted` raised from `#666` to `#999`
- `.telem-label` raised to `#bbb`
- Map nav arrow buttons raised to `#ccc`
- Canvas axis tick labels raised from 28 % to 60 % opacity
- G-force axis ring labels raised from 25 % to 55 % opacity

### AI debrief improvements
- Per-lap telem stats now include avg gear, max steering angle, and per-tyre wear (FL/FR/RL/RR at lap completion)
- Front wing damage parsed and stored in state
- Prompt rewritten: 2–3 plain paragraphs, no bullet points, direct engineer voice, 180-word cap
- `max_tokens` reduced 800 → 500 to enforce shorter output

### Landing page
- Team themes feature card removed

## Test plan
- [ ] SESSION tab: click a lap row — telemetry panel appears; click again — dismisses
- [ ] RACE tab fits on screen without scrolling once telemetry is live
- [ ] Tyre status diagram appears below G-force with correct wear colours
- [ ] With damage data present: red overlay appears on affected tyres; front wing panels tint independently
- [ ] `▲ DAMAGE` legend only visible when damage ≥ 10 %
- [ ] Map arrows, chart labels, and axis ticks are clearly readable
- [ ] AI debrief is noticeably shorter and less robotic in tone

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg