### PR TITLE
Fix TypeError in AI debrief tyre wear formatting

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -676,13 +676,11 @@ def parse_lap_data_packet(data, player_idx):
                 "avg_gear":          round(avg_gear, 1),
                 "max_steer":         round(max_steer, 2),
             }
-            # Capture tyre wear at lap completion (FL, FR, RL, RR)
+            # Capture tyre wear at lap completion (FL, FR, RL, RR) — only store non-None values
             tw = state.get("tyre_wear", [None, None, None, None])
-            if any(v is not None for v in tw):
-                lap_record["telem"]["tyre_wear_fl"] = round(tw[2]) if tw[2] is not None else None
-                lap_record["telem"]["tyre_wear_fr"] = round(tw[3]) if tw[3] is not None else None
-                lap_record["telem"]["tyre_wear_rl"] = round(tw[0]) if tw[0] is not None else None
-                lap_record["telem"]["tyre_wear_rr"] = round(tw[1]) if tw[1] is not None else None
+            for idx, key in ((2, "tyre_wear_fl"), (3, "tyre_wear_fr"), (0, "tyre_wear_rl"), (1, "tyre_wear_rr")):
+                if tw[idx] is not None:
+                    lap_record["telem"][key] = round(tw[idx])
 
         if save_session_id is not None:
             db_save_lap(save_session_id, lap_record, trace=saved_trace)

--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -409,7 +409,10 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
     # Build telemetry table if any laps have telem data
     telem_laps = [lap for lap in laps if lap.get("telem")]
     telem_section = ""
-    has_tyre_wear = any(lap.get("telem", {}).get("tyre_wear_fl") is not None for lap in telem_laps)
+    def _tv(v):
+        """Return value for table cell, replacing None/missing with a dash."""
+        return v if v is not None else '—'
+    has_tyre_wear = any(_tv(lap.get("telem", {}).get("tyre_wear_fl")) != '—' for lap in telem_laps)
     if telem_laps:
         th = "Lap | MaxSpd | AvgSpd | FullThr% | HvyBrk% | MaxGLat | AvgGear | MaxSteer"
         if has_tyre_wear:
@@ -418,21 +421,21 @@ def debrief(req: func.HttpRequest) -> func.HttpResponse:
         for lap in telem_laps:
             t = lap["telem"]
             row = (
-                f"Lap {lap.get('lap_num', '?'):>3} | "
-                f"{t.get('max_speed', '—'):>6} | "
-                f"{t.get('avg_speed', '—'):>6} | "
-                f"{t.get('full_throttle_pct', '—'):>8} | "
-                f"{t.get('heavy_brake_pct', '—'):>7} | "
-                f"{t.get('max_g_lat', '—'):>7} | "
-                f"{t.get('avg_gear', '—'):>7} | "
-                f"{t.get('max_steer', '—'):>8}"
+                f"Lap {_tv(lap.get('lap_num')):>3} | "
+                f"{str(_tv(t.get('max_speed'))):>6} | "
+                f"{str(_tv(t.get('avg_speed'))):>6} | "
+                f"{str(_tv(t.get('full_throttle_pct'))):>8} | "
+                f"{str(_tv(t.get('heavy_brake_pct'))):>7} | "
+                f"{str(_tv(t.get('max_g_lat'))):>7} | "
+                f"{str(_tv(t.get('avg_gear'))):>7} | "
+                f"{str(_tv(t.get('max_steer'))):>8}"
             )
             if has_tyre_wear:
                 row += (
-                    f" | {t.get('tyre_wear_fl', '—'):>3}"
-                    f" | {t.get('tyre_wear_fr', '—'):>3}"
-                    f" | {t.get('tyre_wear_rl', '—'):>3}"
-                    f" | {t.get('tyre_wear_rr', '—'):>3}"
+                    f" | {str(_tv(t.get('tyre_wear_fl'))):>3}"
+                    f" | {str(_tv(t.get('tyre_wear_fr'))):>3}"
+                    f" | {str(_tv(t.get('tyre_wear_rl'))):>3}"
+                    f" | {str(_tv(t.get('tyre_wear_rr'))):>3}"
                 )
             trows.append(row)
         telem_section = (


### PR DESCRIPTION
## Summary

- `f"{None:>3}"` raises `TypeError` in Python 3 when a dict value exists but is `None`
- `F1_lap_tracker.py`: only write tyre wear keys into `lap_record["telem"]` when the value is not `None`, so missing keys fall back correctly to `'—'` in the prompt table
- `leaderboard_api/function_app.py`: add `_tv()` helper that converts `None` → `'—'`; wrap all telem cell values with `str()` before applying format specs

## Test plan

- [ ] Trigger AI debrief after a session where tyre wear was partially/fully unavailable — should return debrief without a 500 error
- [ ] Trigger AI debrief in a normal session with full tyre wear data — table renders correctly

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg