### PR TITLE
Improve tyre diagram SVG and fix AI debrief error visibility

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -1423,8 +1423,22 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_header("Content-Length", len(out))
                 self.end_headers()
                 self.wfile.write(out)
-            except urllib.error.URLError:
+            except urllib.error.HTTPError as exc:
+                body = exc.read().decode("utf-8", errors="replace")
+                log.warning("AI debrief HTTP %s: %s", exc.code, body)
+                try:
+                    msg = json.loads(body).get("error") or body
+                except Exception:
+                    msg = body or f"HTTP {exc.code}"
+                err = json.dumps({"error": msg}).encode()
+                self.send_response(exc.code if exc.code in (400, 429) else 500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", len(err))
+                self.end_headers()
+                self.wfile.write(err)
+            except urllib.error.URLError as exc:
                 _warn_backend_unreachable("AI Debrief")
+                log.warning("AI debrief URLError: %s", exc)
                 err = json.dumps({"error": "AI debrief backend is currently unreachable. Please try again later."}).encode()
                 self.send_response(503)
                 self.send_header("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

- Redesigned tyre status SVG to match the reference flat-design illustration — two wide horizontal front wing panels with endplates and centre pylon, suspension wishbone lines, floor/sidepod boundary panel lines, centre cross body detail, bolder 2px strokes throughout
- Fixed front wing damage threshold: was `>= 10%`, now `> 0` — most F1 25 wing taps register below 10% so damage was never showing
- Fixed tyre damage overlay threshold from `>= 5%` to `> 0`
- Added minimum 18% opacity on all damage fills so even 1% damage is clearly visible
- Fixed AI debrief error handling: `urllib.error.HTTPError` (a subclass of `URLError`) was being caught by the generic `URLError` handler, masking the real error response from the Azure Function — now HTTP errors are caught first, the response body is read and returned to the browser so the actual error message is shown instead of the generic "unreachable" message

## Test plan

- [ ] Load dashboard with an active session — tyre status diagram shows correct tyre colours
- [ ] Take front wing damage in-game — affected panel(s) tint red immediately
- [ ] Trigger AI debrief — on success, debrief renders normally; on error, the actual error message appears (not just "unreachable")

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg