### PR TITLE
fix: correct front wing damage byte offset for F1 25

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -811,12 +811,12 @@ def parse_car_damage_packet(data, player_idx):
         wear   = struct.unpack_from("<4f", data, base +  0)
         damage = struct.unpack_from("<4B", data, base + 16)
         valid  = [round(w, 1) if 0.0 <= w <= 100.0 else None for w in wear]
-        # Debug: dump full remaining bytes +20..+45 (per_car=46 in F1 25)
-        raw_slice = list(data[base + 20 : base + per_car])
-        print(f"[CarDamage] per_car={per_car} tyreDmg={list(damage)} bytes+20..+{per_car-1}={raw_slice}")
+        # F1 25 (per_car=46) inserted 4 bytes at +24..+27 shifting wing damage
+        # to +28/+29. F1 24 (per_car=41) had it at +24/+25.
+        fw_off = 28 if per_car >= 46 else 24
         fw_dmg = [None, None]
-        if len(data) >= base + 26:
-            fw_dmg = list(struct.unpack_from("<2B", data, base + 24))
+        if len(data) >= base + fw_off + 2:
+            fw_dmg = list(struct.unpack_from("<2B", data, base + fw_off))
         with state_lock:
             state["tyre_wear"]          = valid
             state["tyre_damage"]        = list(damage)

--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -811,10 +811,9 @@ def parse_car_damage_packet(data, player_idx):
         wear   = struct.unpack_from("<4f", data, base +  0)
         damage = struct.unpack_from("<4B", data, base + 16)
         valid  = [round(w, 1) if 0.0 <= w <= 100.0 else None for w in wear]
-        # Debug: dump bytes +20 to +35 so we can identify the correct front-wing offset
-        raw_slice = list(data[base + 20 : base + 36])
-        print(f"[CarDamage] per_car={per_car} wear={[round(w,1) for w in wear]} "
-              f"tyreDmg={list(damage)} bytes+20..+35={raw_slice}")
+        # Debug: dump full remaining bytes +20..+45 (per_car=46 in F1 25)
+        raw_slice = list(data[base + 20 : base + per_car])
+        print(f"[CarDamage] per_car={per_car} tyreDmg={list(damage)} bytes+20..+{per_car-1}={raw_slice}")
         fw_dmg = [None, None]
         if len(data) >= base + 26:
             fw_dmg = list(struct.unpack_from("<2B", data, base + 24))


### PR DESCRIPTION
## Summary

- F1 25 expanded the Car Damage packet per-car stride from 41 → 46 bytes by inserting 4 bytes at offsets +24..+27 (between `brakesDamage` and the front wing fields)
- This shifted `frontLeftWingDamage` +24 → +28 and `frontRightWingDamage` +25 → +29, so the old hardcoded offset always read zero even after real wing damage
- Fix detects the game version via per-car stride (`>= 46` → F1 25) and reads from +28/+29 or +24/+25 accordingly — no hardcoded game version check needed

## Test plan

- [ ] Deliberately damage front-left wing in F1 25 — confirm left wing SVG overlay appears
- [ ] Deliberately damage front-right wing in F1 25 — confirm right wing SVG overlay appears
- [ ] Verify tyre wear and tyre damage readings are unaffected
- [ ] Confirm F1 24 wing damage still works (per_car=41 path reads +24/+25)

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg