### PR TITLE
feat: session tab speed gauge, tyre diagram, and map scrubber

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -207,11 +207,16 @@ def init_db():
             FOREIGN KEY (session_id) REFERENCES sessions(id)
         )
     """)
-    # Migration: add trace column if upgrading from older DB
-    try:
-        con.execute("ALTER TABLE laps ADD COLUMN trace TEXT")
-    except Exception as e:
-        log.debug("DB migration (expected on existing DB): %s", e)
+    # Migrations — each ALTER TABLE is a no-op if the column already exists
+    for col_ddl in (
+        "ALTER TABLE laps ADD COLUMN trace TEXT",
+        "ALTER TABLE laps ADD COLUMN tyre_wear TEXT",
+        "ALTER TABLE laps ADD COLUMN tyre_damage TEXT",
+    ):
+        try:
+            con.execute(col_ddl)
+        except Exception as e:
+            log.debug("DB migration (expected on existing DB): %s", e)
     con.execute("""
         CREATE TABLE IF NOT EXISTS personal_bests (
             track        TEXT NOT NULL,
@@ -283,16 +288,19 @@ def db_close_session(session_id):
     con.commit()
     con.close()
 
-def db_save_lap(session_id, lap, trace=None):
+def db_save_lap(session_id, lap, trace=None, tyre_wear=None, tyre_damage=None):
     con = sqlite3.connect(DB_PATH)
     con.execute(
         """INSERT INTO laps
-           (session_id, lap_num, lap_time_ms, lap_time, s1_ms, s2_ms, s3_ms, invalid, timestamp, compound, trace)
-           VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+           (session_id, lap_num, lap_time_ms, lap_time, s1_ms, s2_ms, s3_ms,
+            invalid, timestamp, compound, trace, tyre_wear, tyre_damage)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)""",
         (session_id, lap["lap_num"], lap["lap_time_ms"], lap["lap_time"],
          lap["s1_ms"], lap["s2_ms"], lap["s3_ms"], int(lap["invalid"]),
          lap["timestamp"], lap.get("compound"),
-         json.dumps(trace) if trace else None)
+         json.dumps(trace) if trace else None,
+         json.dumps(tyre_wear) if tyre_wear else None,
+         json.dumps(tyre_damage) if tyre_damage else None)
     )
     con.commit()
     con.close()
@@ -646,12 +654,15 @@ def parse_lap_data_packet(data, player_idx):
 
         # Save current lap trace as track outline reference, then reset for next lap
         saved_trace = None
+        saved_tyre_wear = saved_tyre_damage = None
         if save_session_id is not None:
             with state_lock:
                 if state["lap_trace"]:
                     saved_trace = list(state["lap_trace"])
                     state["track_outline"] = saved_trace
                 state["lap_trace"] = []
+                saved_tyre_wear   = list(state.get("tyre_wear")   or [None] * 4)
+                saved_tyre_damage = list(state.get("tyre_damage") or [None] * 4)
 
         # Compute aggregate telemetry stats from the trace and store in lap record
         if saved_trace:
@@ -683,7 +694,8 @@ def parse_lap_data_packet(data, player_idx):
                     lap_record["telem"][key] = round(tw[idx])
 
         if save_session_id is not None:
-            db_save_lap(save_session_id, lap_record, trace=saved_trace)
+            db_save_lap(save_session_id, lap_record, trace=saved_trace,
+                        tyre_wear=saved_tyre_wear, tyre_damage=saved_tyre_damage)
         if save_pb_data is not None:
             db_upsert_track_pb(*save_pb_data)
             with state_lock:
@@ -1298,12 +1310,18 @@ class Handler(BaseHTTPRequestHandler):
                 lap_num    = int(parts[-1])
                 con = sqlite3.connect(DB_PATH)
                 row = con.execute(
-                    "SELECT trace FROM laps WHERE session_id=? AND lap_num=?",
+                    "SELECT trace, tyre_wear, tyre_damage FROM laps WHERE session_id=? AND lap_num=?",
                     (session_id, lap_num)
                 ).fetchone()
                 con.close()
-                trace_data = json.loads(row[0]) if row and row[0] else []
-                payload = json.dumps({"trace": trace_data}).encode()
+                trace_data      = json.loads(row[0]) if row and row[0] else []
+                tyre_wear_data  = json.loads(row[1]) if row and len(row) > 1 and row[1] else None
+                tyre_damage_data= json.loads(row[2]) if row and len(row) > 2 and row[2] else None
+                payload = json.dumps({
+                    "trace":       trace_data,
+                    "tyre_wear":   tyre_wear_data,
+                    "tyre_damage": tyre_damage_data,
+                }).encode()
                 self.send_response(200)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", len(payload))

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -622,8 +622,11 @@ backdrop-filter: blur(4px);
             <canvas id="steer-canvas-sr" width="600" height="55" style="width:100%;display:block;"></canvas>
           </div>
           <div class="telem-gforce-wrap">
+            <div class="telem-label">SPEED</div>
+            <div id="sr-speed-slot" style="margin-bottom:14px;"></div>
             <div class="telem-label">G-FORCE</div>
             <canvas id="gforce-canvas-sr" width="220" height="220" style="display:block;width:100%;"></canvas>
+            <div id="tyre-wear-slot-sr" style="margin-top:10px;"></div>
           </div>
         </div>
       </div>
@@ -1241,9 +1244,17 @@ async function selectSessionLap(lapNum) {
     const r = await fetch(`/api/lap-trace/${sid}/${lapNum}`);
     const d = await r.json();
     const trace = d.trace || [];
+    _srSessionTrace = trace;
+    _srHoverIdx = -1;
     if (waiting) waiting.style.display = 'none';
     if (charts) charts.style.display = '';
     renderTelemetry(trace, null, '-sr');
+    // Show this lap's trace on the sidebar map (locks out live updates)
+    renderTrackMap({ lap_trace: trace, track_outline: _lastGoodOutline, car_pos: null });
+    // Populate right-column slots
+    const srTyreSlot = document.getElementById('tyre-wear-slot-sr');
+    if (srTyreSlot) srTyreSlot.innerHTML = renderTyreDiagram({ tyre_wear: d.tyre_wear, tyre_damage: d.tyre_damage });
+    renderSpeedGauge(trace[0] ? trace[0].speed : 0, 'sr-speed-slot');
   } catch(e) {
     if (waiting) waiting.textContent = 'Failed to load trace.';
   }
@@ -1251,6 +1262,8 @@ async function selectSessionLap(lapNum) {
 
 function closeSessionReview() {
   _selectedSessionLap = null;
+  _srSessionTrace = [];
+  _srHoverIdx = -1;
   const sec = document.getElementById('session-review-section');
   if (sec) sec.style.display = 'none';
   if (lastData) render(lastData);
@@ -2065,8 +2078,8 @@ function renderRevLights(pct, gear) {
   }
 }
 
-function renderSpeedGauge(speed) {
-  const slot = document.getElementById('live-speed-slot');
+function renderSpeedGauge(speed, slotId = 'live-speed-slot') {
+  const slot = document.getElementById(slotId);
   if (!slot) return;
 
   let canvas = slot.querySelector('canvas');
@@ -2138,6 +2151,117 @@ function renderSpeedGauge(speed) {
   ctx.fillStyle = 'rgba(255,255,255,.42)';
   ctx.font = `500 10px 'Inter', sans-serif`;
   ctx.fillText('km/h', cx, cy + 32);
+}
+
+// ── Session-review scrubber ────────────────────────────────────────────────────
+let _srSessionTrace = [];
+let _srHoverIdx     = -1;
+let _srHoverRaf     = null;
+
+function _srSetHover(idx) {
+  _srHoverIdx = idx;
+  if (_srHoverRaf) cancelAnimationFrame(_srHoverRaf);
+  _srHoverRaf = requestAnimationFrame(_srApplyHover);
+}
+
+function _srApplyHover() {
+  _srHoverRaf = null;
+  const idx   = _srHoverIdx;
+  const trace = _srSessionTrace;
+  if (!trace.length) return;
+
+  renderTelemetry(trace, null, '-sr');
+
+  if (idx >= 0 && idx < trace.length) {
+    _srDrawCrosshair(idx, trace.length);
+    renderTrackMap({ lap_trace: trace, track_outline: _lastGoodOutline, car_pos: null });
+    _srHighlightMapPoint(idx, trace);
+    renderSpeedGauge(trace[idx].speed, 'sr-speed-slot');
+  } else {
+    renderTrackMap({ lap_trace: trace, track_outline: _lastGoodOutline, car_pos: null });
+    renderSpeedGauge(trace[0] ? trace[0].speed : 0, 'sr-speed-slot');
+  }
+}
+
+function _srDrawCrosshair(idx, nPts) {
+  const frac     = idx / Math.max(nPts - 1, 1);
+  const stdPad   = _chartPad();
+  const inputPad = { t: 2, b: 2, l: 28, r: 4 };
+  const charts   = [
+    { id: 'speed-canvas-sr',  p: stdPad   },
+    { id: 'inputs-canvas-sr', p: inputPad },
+    { id: 'gear-canvas-sr',   p: stdPad   },
+    { id: 'steer-canvas-sr',  p: stdPad   },
+  ];
+  for (const { id, p } of charts) {
+    const canvas = document.getElementById(id);
+    if (!canvas) continue;
+    const ctx = canvas.getContext('2d');
+    const x   = p.l + frac * (canvas.width - p.l - p.r);
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,255,255,.8)';
+    ctx.lineWidth   = 1;
+    ctx.setLineDash([3, 3]);
+    ctx.beginPath();
+    ctx.moveTo(x, p.t);
+    ctx.lineTo(x, canvas.height - p.b);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+function _srHighlightMapPoint(idx, trace) {
+  const canvas = document.getElementById('track-canvas');
+  if (!canvas) return;
+  const ref = (_lastGoodOutline && _lastGoodOutline.length >= trace.length)
+    ? _lastGoodOutline : trace;
+  const b  = _bounds(ref);
+  const cw = canvas.width, ch = canvas.height, pad = 14;
+  const pos = _toCanvas(trace[idx], b, cw, ch, pad);
+  const ctx = canvas.getContext('2d');
+  ctx.save();
+  ctx.shadowBlur  = 14;
+  ctx.shadowColor = '#00d2ff';
+  ctx.fillStyle   = '#00d2ff';
+  ctx.beginPath();
+  ctx.arc(pos.x, pos.y, 5, 0, 2 * Math.PI);
+  ctx.fill();
+  ctx.restore();
+}
+
+function _srChartMouseMove(e, id, isInputPad) {
+  if (!_srSessionTrace.length) return;
+  const canvas = document.getElementById(id);
+  if (!canvas) return;
+  const rect   = canvas.getBoundingClientRect();
+  const pixelX = (e.clientX - rect.left) * (canvas.width / rect.width);
+  const p      = isInputPad ? { l: 28, r: 4 } : _chartPad();
+  const cw     = canvas.width - p.l - p.r;
+  const n      = _srSessionTrace.length;
+  const idx    = Math.max(0, Math.min(n - 1, Math.round(((pixelX - p.l) / cw) * (n - 1))));
+  _srSetHover(idx);
+}
+
+function _srMapMouseMove(e) {
+  if (!_srSessionTrace.length) return;
+  const canvas = document.getElementById('track-canvas');
+  if (!canvas) return;
+  const rect   = canvas.getBoundingClientRect();
+  const mouseX = (e.clientX - rect.left) * (canvas.width / rect.width);
+  const mouseY = (e.clientY - rect.top)  * (canvas.height / rect.height);
+  const trace  = _srSessionTrace;
+  const ref    = (_lastGoodOutline && _lastGoodOutline.length >= trace.length)
+    ? _lastGoodOutline : trace;
+  const b  = _bounds(ref);
+  const cw = canvas.width, ch = canvas.height, pad = 14;
+  let bestIdx = 0, bestDist = Infinity;
+  for (let i = 0; i < trace.length; i++) {
+    const c  = _toCanvas(trace[i], b, cw, ch, pad);
+    const dx = c.x - mouseX, dy = c.y - mouseY;
+    const d2 = dx * dx + dy * dy;
+    if (d2 < bestDist) { bestDist = d2; bestIdx = i; }
+  }
+  _srSetHover(bestIdx);
 }
 
 // ── Track Map ──────────────────────────────────────────────────────────────────
@@ -2319,12 +2443,33 @@ async function fetchMotion() {
     }
     renderRevLights(d.rev_lights_pct || 0, d.car_gear ?? 0);
     renderSpeedGauge(d.car_speed || 0);
-    if (_reviewLap === null) {
+    if (_reviewLap === null && !_srSessionTrace.length) {
       renderTrackMap(d);
       if (!_comparisonActive()) renderTelemetry(d.lap_trace || []);
     }
   } catch(e) {}
 }
+
+// ── Session-review scrubber event listeners ────────────────────────────────────
+[
+  ['speed-canvas-sr',  false],
+  ['inputs-canvas-sr', true],
+  ['gear-canvas-sr',   false],
+  ['steer-canvas-sr',  false],
+].forEach(([id, isInputPad]) => {
+  const el = document.getElementById(id);
+  if (!el) return;
+  el.style.cursor = 'crosshair';
+  el.addEventListener('mousemove', e => _srChartMouseMove(e, id, isInputPad));
+  el.addEventListener('mouseleave', () => { if (_srSessionTrace.length) _srSetHover(-1); });
+});
+
+(function() {
+  const mapEl = document.getElementById('track-canvas');
+  if (!mapEl) return;
+  mapEl.addEventListener('mousemove', _srMapMouseMove);
+  mapEl.addEventListener('mouseleave', () => { if (_srSessionTrace.length) _srSetHover(-1); });
+})();
 
 fetchState();
 fetchPBs();


### PR DESCRIPTION
## Summary

Three interconnected features for the session-tab lap review:

**Speed gauge + tyre diagram**
- Right column now matches the live race tab: speed gauge (`#sr-speed-slot`) + G-Force + tyre diagram (`#tyre-wear-slot-sr`)
- Tyre diagram shows lap-end wear and damage for the reviewed lap
- Backend: added `tyre_wear` / `tyre_damage` columns to the `laps` table (safe `ALTER TABLE` migration), captured under `state_lock` at lap completion, returned by `/api/lap-trace/{session}/{lap}`

**Interactive scrubber**
- Hover over any of the 4 session-review chart canvases → dashed white vertical crosshair syncs across **all 4 charts simultaneously**
- Hover over the **sidebar track map** → nearest trace point is found and crosshairs draw on all charts
- A cyan glow dot highlights the current scrubber position on the map
- Speed gauge updates to the speed at that trace point in real time
- `fetchMotion` skips live map/chart updates while session review is active so the displayed lap trace isn't overwritten
- All hover updates are rAF-debounced — no queuing on fast mousemove

## Test plan

- [ ] Select a lap on the session tab → speed gauge, G-Force, and tyre diagram all appear in right column
- [ ] Hover over speed chart → dashed crosshair appears on all 4 charts; speed gauge shows that point's speed; map shows cyan dot
- [ ] Hover over track map → crosshairs move on all charts to the nearest point
- [ ] Move mouse off canvases → scrubber clears, charts redraw cleanly
- [ ] Close session review → live race tab map/charts resume normally
- [ ] Tyre diagram shows correct wear colours for a lap that had tyre data (new laps after this merge; old laps will show nothing — expected)

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg