### PR TITLE
fix: race tab stuck on waiting after session review

### DIFF
--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -2443,8 +2443,10 @@ async function fetchMotion() {
     }
     renderRevLights(d.rev_lights_pct || 0, d.car_gear ?? 0);
     renderSpeedGauge(d.car_speed || 0);
-    if (_reviewLap === null && !_srSessionTrace.length) {
-      renderTrackMap(d);
+    if (_reviewLap === null) {
+      // Only update the map with live data when not locked to a session-review lap
+      if (!_srSessionTrace.length) renderTrackMap(d);
+      // Always update the race-tab charts so "waiting" clears when data arrives
       if (!_comparisonActive()) renderTelemetry(d.lap_trace || []);
     }
   } catch(e) {}


### PR DESCRIPTION
## Root cause

The `_srSessionTrace` lock in `fetchMotion` was applied to both `renderTrackMap` **and** `renderTelemetry`. Locking the map is correct (keeps the session-review lap visible on the sidebar map while reviewing). But `renderTelemetry` is what shows/hides the race tab's `telemetry-section` vs the "Waiting for live telemetry" placeholder — gating it meant the race tab never received the signal to reveal its charts once data arrived.

## Fix

Split the two conditions: map update respects the `_srSessionTrace` lock, telemetry chart update always runs (still gated only by `_reviewLap === null`).

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg