### PR TITLE
debug: Final Classification packet diagnostics

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -864,6 +864,8 @@ def parse_final_classification_packet(data, player_idx):
         # Dividing by num_cars (e.g. 20) gives the wrong stride (49 instead of
         # 45) and misaligns every field for player_idx > 0.
         per_car = FINAL_CLASS_SIZE
+        # Infer actual stride from packet length to detect F1 25 spec changes.
+        inferred_per_car = (len(data) - base - 1) // 22
         car_base = base + 1 + player_idx * per_car
         if len(data) < car_base + 20:
             return
@@ -876,14 +878,19 @@ def parse_final_classification_packet(data, player_idx):
         total_time_s  = struct.unpack_from("<d", data, car_base + 10)[0]
         best_lap_str  = ms_to_laptime(best_lap_ms) if best_lap_ms > 0 else "—"
 
+        raw = list(data[car_base: car_base + min(20, len(data) - car_base)])
+        print(f"[Final Classification] pkt_len={len(data)} player_idx={player_idx} "
+              f"num_cars={num_cars} per_car_assumed={per_car} inferred={inferred_per_car} "
+              f"raw[0..19]={raw}")
+        print(f"[Final Classification] raw: status={result_status} pos={position} "
+              f"laps={num_laps} best={best_lap_str}")
+
         # Only save when the race is actually over. Status 2 ("Active") is
         # included because F1 25 reports classified finishers (including DNFs
         # from crashes) as Active rather than Finished/Retired in many cases.
         # Status 0 (Invalid) and 1 (Inactive) are still ignored — those are
         # formation-lap / pre-race placeholders.
         FINAL_STATUSES = {2, 3, 4, 5, 6, 7}  # Active, Finished, DNF, DSQ, N/C, Retired
-        print(f"[Final Classification] raw: status={result_status} pos={position} "
-              f"laps={num_laps} best={best_lap_str}")
         if result_status not in FINAL_STATUSES:
             print(f"[Final Classification] ignored — status {result_status} not final")
             return


### PR DESCRIPTION
## Purpose

Temporary diagnostic PR. After merging, do one race and share the terminal output — it will tell us exactly what F1 25 is sending so we can fix the career stats parsing correctly.

The new output will look like:

```
[Final Classification] pkt_len=1020 player_idx=3 num_cars=20 per_car_assumed=45 inferred=45 raw[0..19]=[3, 5, 4, 12, 0, 2, ...]
[Final Classification] raw: status=2 pos=3 laps=5 best=1:32.441
```

Key things to check:
- `inferred` vs `per_car_assumed` — if different, F1 25 changed the struct size
- `raw[0..19]` — actual bytes at your car slot so we can verify field offsets
- `player_idx` — confirms which car slot is being read

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg