### PR TITLE
fix: correct Final Classification per-car stride for F1 25 (46 bytes)

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -860,12 +860,11 @@ def parse_final_classification_packet(data, player_idx):
         num_cars = struct.unpack_from("<B", data, base)[0]
         if player_idx >= num_cars or num_cars == 0:
             return
-        # The packet body always has 22 car entries regardless of num_cars.
-        # Dividing by num_cars (e.g. 20) gives the wrong stride (49 instead of
-        # 45) and misaligns every field for player_idx > 0.
-        per_car = FINAL_CLASS_SIZE
-        # Infer actual stride from packet length to detect F1 25 spec changes.
+        # Infer the per-car stride from packet length (22 entries always present).
+        # F1 24 = 45 bytes/car, F1 25 = 46 bytes/car. Using the inferred value
+        # avoids the 1-byte-per-car drift that corrupts reads for higher car indices.
         inferred_per_car = (len(data) - base - 1) // 22
+        per_car = inferred_per_car if inferred_per_car >= FINAL_CLASS_SIZE else FINAL_CLASS_SIZE
         car_base = base + 1 + player_idx * per_car
         if len(data) < car_base + 20:
             return
@@ -878,11 +877,8 @@ def parse_final_classification_packet(data, player_idx):
         total_time_s  = struct.unpack_from("<d", data, car_base + 10)[0]
         best_lap_str  = ms_to_laptime(best_lap_ms) if best_lap_ms > 0 else "—"
 
-        raw = list(data[car_base: car_base + min(20, len(data) - car_base)])
-        print(f"[Final Classification] pkt_len={len(data)} player_idx={player_idx} "
-              f"num_cars={num_cars} per_car_assumed={per_car} inferred={inferred_per_car} "
-              f"raw[0..19]={raw}")
-        print(f"[Final Classification] raw: status={result_status} pos={position} "
+        print(f"[Final Classification] pkt_len={len(data)} per_car={per_car} "
+              f"player_idx={player_idx} status={result_status} pos={position} "
               f"laps={num_laps} best={best_lap_str}")
 
         # Only save when the race is actually over. Status 2 ("Active") is


### PR DESCRIPTION
## Root cause

The diagnostic output revealed:
```
pkt_len=1042  player_idx=19  per_car_assumed=45  inferred=46
```

F1 25 uses **46 bytes per car** in the Final Classification packet (F1 24 used 45). With `player_idx=19` (last car on a 20-car grid), the 1-byte-per-car drift compounded to **19 bytes of misalignment**, putting `car_base` completely in the wrong place and producing `status=0 / pos=0 / laps=0`.

## Fix

Infer the per-car stride from the packet length (`(pkt_len - header - 1) / 22`) instead of the hardcoded `FINAL_CLASS_SIZE=45` constant. Falls back to the constant if the inferred value is smaller (guards against truncated packets). Field offsets within each entry are unchanged — F1 25 appended the extra byte at the end of the struct.

## Test plan
- [ ] Complete a race — terminal should show `[Final Classification] ... status=2 pos=X laps=Y` with real values
- [ ] Career tab should populate after the race ends
- [ ] Works regardless of grid position (player_idx 0–19)

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg