### PR TITLE
fix: career stats blocked by Unknown session type + weather chip

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -912,9 +912,10 @@ def parse_final_classification_packet(data, player_idx):
         print(f"[Final Classification] status={result_status} pos={position} "
               f"sess='{sess_type}' track='{track}' sid={sid}")
 
-        # Only record career results for race sessions
-        if sess_type not in RACE_SESSION_TYPES:
-            print(f"[Final Classification] skipped — session type '{sess_type}' not a race")
+        # Final Classification is only sent at race end — no session-type gate needed.
+        # Validate using packet data: must have a real position and have completed laps.
+        if position == 0 or num_laps == 0:
+            print(f"[Final Classification] skipped — pos={position} laps={num_laps} (not a real race finish)")
             return
 
         with state_lock:

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -584,6 +584,8 @@ backdrop-filter: blur(4px);
           <div id="sector-chip-1" class="sector-chip">S1 —</div>
           <div id="sector-chip-2" class="sector-chip">S2 —</div>
           <div id="sector-chip-3" class="sector-chip">S3 —</div>
+          <div style="flex:1;"></div>
+          <div id="weather-chip" class="sector-chip">—</div>
         </div>
       </div>
       <div id="telemetry-section" style="display:none;">
@@ -2146,6 +2148,16 @@ function renderSectorStrip(d) {
     chip.textContent = `${label} ${s}.${rem}${deltaStr}`;
     if (delta !== null) chip.classList.add(delta < 0 ? 's-green' : 's-red');
   });
+
+  const weatherChip = document.getElementById('weather-chip');
+  if (weatherChip) {
+    const wx = lastData?.session?.weather || '';
+    const WEATHER_ICON = {
+      'Clear': '☀ Clear', 'Light Cloud': '⛅ Lt Cloud', 'Overcast': '☁ Overcast',
+      'Light Rain': '🌦 Lt Rain', 'Heavy Rain': '🌧 Hvy Rain', 'Storm': '⛈ Storm',
+    };
+    weatherChip.textContent = WEATHER_ICON[wx] || (wx || '—');
+  }
 }
 
 // ── Fuel bar ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Career stats fix** — removed the `session_type == 'Race'` gate from the Final Classification parser. The packet is only ever sent at race end, so the gate was silently dropping career results whenever the session resolved as `'Unknown'` (career mode, mid-session app start, results screen timing, etc.). Now validates purely from packet data: `position > 0` and `num_laps > 0`.
- **Weather chip** — sits on the right end of the sector strip row showing current conditions (☀ Clear, ⛅ Lt Cloud, 🌦 Lt Rain, ⛈ Storm, etc.) without adding any vertical space.

## Test plan

- [ ] Finish a career race — confirm career stats (races, wins, podiums, points) now populate
- [ ] Confirm the weather chip appears on the right side of the sector strip during a session
- [ ] Verify no regression on existing race tab features

https://claude.ai/code/session_01YJvxwcau1wHU8Bos21LeFg