### PR TITLE
feat: add submission date to leaderboard and strengthen name filter

### DIFF
--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -78,6 +78,30 @@ def _normalize_name(name: str) -> str:
     return " ".join(name.lower().split())
 
 
+_LEET_MAP = str.maketrans({
+    "4": "a", "@": "a", "^": "a",
+    "8": "b",
+    "3": "e", "&": "e",
+    "1": "i", "!": "i", "|": "i",
+    "5": "s", "$": "s",
+    "7": "t", "+": "t",
+    "0": "o",
+    "9": "g",
+    "6": "b",
+    "2": "z",
+})
+
+
+def _deleet(name: str) -> str:
+    """Replace common leetspeak substitutions so profanity check catches evasions."""
+    return name.lower().translate(_LEET_MAP)
+
+
+def _contains_profanity(name: str) -> bool:
+    """Check both the original name and its de-leeted form."""
+    return _profanity.contains_profanity(name) or _profanity.contains_profanity(_deleet(name))
+
+
 def _check_and_register_name(display_name: str, player_id: str):
     """Return an error string if the name is taken, otherwise register it.
 
@@ -137,7 +161,7 @@ def _handle_submit(body) -> func.HttpResponse:
         return _error("display_name must be between 1 and 32 characters.")
     if not all(c.isprintable() for c in display_name):
         return _error("display_name contains invalid characters.")
-    if _profanity.contains_profanity(display_name):
+    if _contains_profanity(display_name):
         return _error("That display name isn't allowed. Please choose a different name.")
     name_conflict = _check_and_register_name(display_name, player_id)
     if name_conflict:
@@ -232,7 +256,7 @@ def leaderboard(req: func.HttpRequest) -> func.HttpResponse:
     container = _get_container(LEADERBOARD_CONTAINER)
 
     top_query = (
-        "SELECT c.player_id, c.display_name, c.lap_time, c.lap_time_ms, c.compound "
+        "SELECT c.player_id, c.display_name, c.lap_time, c.lap_time_ms, c.compound, c.submitted_at "
         "FROM c "
         "WHERE c.track_session = @pk "
         "ORDER BY c.track_session ASC, c.lap_time_ms ASC "
@@ -261,6 +285,7 @@ def leaderboard(req: func.HttpRequest) -> func.HttpResponse:
             "lap_time": item.get("lap_time", ""),
             "lap_time_ms": item.get("lap_time_ms", 0),
             "compound": item.get("compound", ""),
+            "submitted_at": item.get("submitted_at", ""),
             "is_player": is_player,
         })
 

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1069,6 +1069,13 @@ async function renderCommunity() {
   } catch(e) {}
 }
 
+function _fmtLbDate(iso) {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: '2-digit' });
+  } catch { return '—'; }
+}
+
 function renderLeaderboard(d) {
   const el = document.getElementById('lb-section');
   if (!d || !d.entries || d.entries.length === 0) {
@@ -1081,11 +1088,13 @@ function renderLeaderboard(d) {
   let rows = '';
   for (const e of d.entries) {
     const top3 = e.rank <= 3 ? 'top3' : '';
+    const dateStr = e.submitted_at ? _fmtLbDate(e.submitted_at) : '—';
     rows += `<tr class="${e.is_player ? 'lb-player' : ''}">
       <td class="lb-rank ${top3}">${e.rank}</td>
       <td class="lap-time">${e.lap_time}</td>
       <td>${compoundPill(e.compound)}</td>
       <td style="font-size:.78rem">${esc(e.display_name)}</td>
+      <td style="font-size:.72rem;color:var(--muted)">${dateStr}</td>
     </tr>`;
   }
   const rankNote = d.player_rank
@@ -1098,7 +1107,7 @@ function renderLeaderboard(d) {
     </div>
     <div class="lap-table-wrap">
       <table>
-        <thead><tr><th>#</th><th>TIME</th><th>TYRE</th><th>DRIVER</th></tr></thead>
+        <thead><tr><th>#</th><th>TIME</th><th>TYRE</th><th>DRIVER</th><th>DATE</th></tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>


### PR DESCRIPTION
- Leaderboard now returns and displays submitted_at date for each entry
- Added _deleet() leetspeak normalization (4→a, 3→e, 0→o, etc.) so
  profanity checks catch evasions like "4ss" or "sh1t"
- Profanity check now runs against both the original name and the
  de-leeted form via new _contains_profanity() helper

https://claude.ai/code/session_0142GXxxzS28rnyVN4b7eTps