### PR TITLE
feat: add iRacing telemetry support

### DIFF
--- a/F1_lap_tracker.py
+++ b/F1_lap_tracker.py
@@ -122,6 +122,8 @@ state = {
     "fuel_capacity":     None,                      # tank capacity kg (from Car Status)
     "fuel_remaining_laps": None,                    # estimated laps of fuel remaining (from Car Status)
     "update_available":  None,                      # set to version string when update is downloaded
+    "sim":               "F1",                      # active telemetry source: "F1" or "iRacing"
+    "iracing_connected": False,                     # True when iRacing shared memory is readable
 }
 
 TRACK_IDS = {
@@ -227,18 +229,56 @@ def init_db():
             con.execute(col_ddl)
         except Exception as e:
             log.debug("DB migration (expected on existing DB): %s", e)
-    con.execute("""
-        CREATE TABLE IF NOT EXISTS personal_bests (
-            track        TEXT NOT NULL,
-            session_type TEXT NOT NULL,
-            lap_time_ms  INTEGER NOT NULL,
-            lap_time     TEXT NOT NULL,
-            compound     TEXT,
-            set_at       TEXT,
-            session_id   INTEGER,
-            PRIMARY KEY (track, session_type)
-        )
-    """)
+    # personal_bests: recreate with sim in PK if the column is missing
+    pb_cols = [r[1] for r in con.execute("PRAGMA table_info(personal_bests)").fetchall()]
+    if "sim" not in pb_cols:
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS personal_bests (
+                track        TEXT NOT NULL,
+                session_type TEXT NOT NULL,
+                lap_time_ms  INTEGER NOT NULL,
+                lap_time     TEXT NOT NULL,
+                compound     TEXT,
+                set_at       TEXT,
+                session_id   INTEGER,
+                PRIMARY KEY (track, session_type)
+            )
+        """)
+        con.execute("""
+            CREATE TABLE personal_bests_v2 (
+                sim          TEXT NOT NULL DEFAULT 'F1',
+                track        TEXT NOT NULL,
+                session_type TEXT NOT NULL,
+                lap_time_ms  INTEGER NOT NULL,
+                lap_time     TEXT NOT NULL,
+                compound     TEXT,
+                set_at       TEXT,
+                session_id   INTEGER,
+                PRIMARY KEY (sim, track, session_type)
+            )
+        """)
+        con.execute("""
+            INSERT INTO personal_bests_v2
+                (sim, track, session_type, lap_time_ms, lap_time, compound, set_at, session_id)
+            SELECT 'F1', track, session_type, lap_time_ms, lap_time, compound, set_at, session_id
+            FROM personal_bests
+        """)
+        con.execute("DROP TABLE personal_bests")
+        con.execute("ALTER TABLE personal_bests_v2 RENAME TO personal_bests")
+    else:
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS personal_bests (
+                sim          TEXT NOT NULL DEFAULT 'F1',
+                track        TEXT NOT NULL,
+                session_type TEXT NOT NULL,
+                lap_time_ms  INTEGER NOT NULL,
+                lap_time     TEXT NOT NULL,
+                compound     TEXT,
+                set_at       TEXT,
+                session_id   INTEGER,
+                PRIMARY KEY (sim, track, session_type)
+            )
+        """)
     con.execute("""
         CREATE TABLE IF NOT EXISTS race_results (
             id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -261,6 +301,8 @@ def init_db():
     for col in [
         "ALTER TABLE laps ADD COLUMN compound TEXT",
         "ALTER TABLE laps ADD COLUMN is_track_pb INTEGER DEFAULT 0",
+        "ALTER TABLE sessions ADD COLUMN sim TEXT DEFAULT 'F1'",
+        "ALTER TABLE race_results ADD COLUMN sim TEXT DEFAULT 'F1'",
     ]:
         try:
             con.execute(col)
@@ -269,11 +311,11 @@ def init_db():
     con.commit()
     con.close()
 
-def db_create_session(track, session_type, weather, started_at):
+def db_create_session(track, session_type, weather, started_at, sim="F1"):
     con = sqlite3.connect(DB_PATH)
     cur = con.execute(
-        "INSERT INTO sessions (track, session_type, weather, started_at) VALUES (?,?,?,?)",
-        (track, session_type, weather, started_at)
+        "INSERT INTO sessions (track, session_type, weather, started_at, sim) VALUES (?,?,?,?,?)",
+        (track, session_type, weather, started_at, sim)
     )
     session_id = cur.lastrowid
     con.commit()
@@ -315,23 +357,23 @@ def db_save_lap(session_id, lap, trace=None, tyre_wear=None, tyre_damage=None):
     con.commit()
     con.close()
 
-def db_get_track_pb(track, session_type):
+def db_get_track_pb(track, session_type, sim="F1"):
     con = sqlite3.connect(DB_PATH)
     con.row_factory = sqlite3.Row
     row = con.execute(
-        "SELECT * FROM personal_bests WHERE track=? AND session_type=?",
-        (track, session_type)
+        "SELECT * FROM personal_bests WHERE sim=? AND track=? AND session_type=?",
+        (sim, track, session_type)
     ).fetchone()
     con.close()
     return dict(row) if row else None
 
-def db_upsert_track_pb(track, session_type, lap_time_ms, lap_time, compound, session_id, set_at):
+def db_upsert_track_pb(track, session_type, lap_time_ms, lap_time, compound, session_id, set_at, sim="F1"):
     con = sqlite3.connect(DB_PATH)
     con.execute(
         """INSERT OR REPLACE INTO personal_bests
-           (track, session_type, lap_time_ms, lap_time, compound, session_id, set_at)
-           VALUES (?,?,?,?,?,?,?)""",
-        (track, session_type, lap_time_ms, lap_time, compound, session_id, set_at)
+           (sim, track, session_type, lap_time_ms, lap_time, compound, session_id, set_at)
+           VALUES (?,?,?,?,?,?,?,?)""",
+        (sim, track, session_type, lap_time_ms, lap_time, compound, session_id, set_at)
     )
     con.commit()
     con.close()
@@ -503,6 +545,7 @@ def parse_session_packet(data, player_idx):
             state["session"]["track"]   = track_name
             state["total_laps"]         = total_laps_val
             state["udp_connected"]      = True
+            state["sim"]                = "F1"
             if state["session"]["started_at"] is None:
                 started_at = datetime.now().isoformat()
                 state["session"]["started_at"] = started_at
@@ -520,7 +563,7 @@ def parse_session_packet(data, player_idx):
             db_update_session(current_session_id, track_name, effective_session_name, weather_name)
 
         if load_pb:
-            pb = db_get_track_pb(track_name, effective_session_name)
+            pb = db_get_track_pb(track_name, effective_session_name, sim="F1")
             with state_lock:
                 if pb:
                     state["track_pb_ms"]       = pb["lap_time_ms"]
@@ -707,7 +750,7 @@ def parse_lap_data_packet(data, player_idx):
             db_save_lap(save_session_id, lap_record, trace=saved_trace,
                         tyre_wear=saved_tyre_wear, tyre_damage=saved_tyre_damage)
         if save_pb_data is not None:
-            db_upsert_track_pb(*save_pb_data)
+            db_upsert_track_pb(*save_pb_data, sim="F1")
             with state_lock:
                 _opt_in  = state.get("leaderboard_opt_in", False)
                 _pid     = state.get("player_id", "")
@@ -1067,6 +1110,7 @@ def _lb_seed_all():
     for pb in pbs:
         if not pb.get("lap_time_ms"):
             continue
+        pb_sim = pb.get("sim", "F1")
         result = _lb_post({
             "player_id":    player_id,
             "display_name": display_name,
@@ -1076,6 +1120,7 @@ def _lb_seed_all():
             "lap_time":     pb["lap_time"],
             "compound":     pb.get("compound") or "",
             "submitted_at": now,
+            "sim":          pb_sim,
         }, background=False)
         ok = result and result.get("ok")
         print(f"[lb-seed] {pb['track']} / {pb['session_type']}: {'ok rank #' + str(result.get('rank')) if ok else result}")
@@ -1095,6 +1140,7 @@ def _lb_refresh(track_override=None, session_type_override=None):
             track        = track_override or state["session"].get("track", "Unknown")
             session_type = session_type_override or state["session"].get("session_type", "Unknown")
             player_id    = state.get("player_id") or ""
+            sim          = state.get("sim", "F1")
         if track in ("Unknown", None, ""):
             # No active session — fall back to the most recently driven track
             con = sqlite3.connect(DB_PATH)
@@ -1108,7 +1154,7 @@ def _lb_refresh(track_override=None, session_type_override=None):
             track, session_type = row[0], row[1]
         url = (f"{LEADERBOARD_URL}/api/leaderboard"
                f"/{quote(track, safe='')}/{quote(session_type, safe='')}"
-               f"?player_id={player_id}")
+               f"?player_id={player_id}&sim={quote(sim, safe='')}")
         with urlopen(url, timeout=10) as resp:  # nosec B310 — scheme validated at startup
             data = json.loads(resp.read())
         with state_lock:
@@ -1619,6 +1665,25 @@ def main():
     # Start UDP listener in background
     t = threading.Thread(target=udp_listener, daemon=True)
     t.start()
+
+    # Optionally start iRacing source (requires pyirsdk on Windows)
+    try:
+        from iracing_source import start_iracing_source, IRACING_AVAILABLE
+        if IRACING_AVAILABLE:
+            ir_callbacks = {
+                "db_create_session": db_create_session,
+                "db_close_session":  db_close_session,
+                "db_save_lap":       db_save_lap,
+                "db_get_track_pb":   db_get_track_pb,
+                "db_upsert_track_pb": db_upsert_track_pb,
+                "lb_post":           _lb_post,
+            }
+            start_iracing_source(state, state_lock, ir_callbacks)
+            print("🏁  iRacing source active (waiting for iRacing...)")
+        else:
+            print("ℹ️   iRacing support: install pyirsdk to enable")
+    except ImportError:
+        pass  # iracing_source.py not present — F1-only mode
 
     # Check for updates in background (after startup settles)
     threading.Thread(target=_check_and_apply_update, daemon=True).start()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pitwall IQ
 
-A lightweight local lap time tracker for **F1 25** (and F1 24/23) on PC. Captures lap times, sector splits, live telemetry, and race results automatically via the game's built-in UDP telemetry — no mods or third-party middleware required.
+A lightweight local lap time tracker for **F1 25** (F1 24/23) and **iRacing** on PC. Captures lap times, sector splits, live telemetry, and race results automatically — no mods or third-party middleware required.
 
 -----
 
@@ -35,7 +35,12 @@ A lightweight local lap time tracker for **F1 25** (and F1 24/23) on PC. Capture
 
 - Python 3.8+
 
-No third-party packages required — everything uses the Python standard library.
+**F1 mode** — no third-party packages required. Everything uses the Python standard library.
+
+**iRacing mode** — requires `pyirsdk` (Windows only, one-time install):
+```bash
+pip install pyirsdk
+```
 
 > SQLite is part of Python's standard library. The AI debrief and community leaderboard features use `urllib` (also stdlib) to communicate with the shared Pitwall IQ backend.
 
@@ -43,7 +48,9 @@ No third-party packages required — everything uses the Python standard library
 
 ## Quick Start
 
-### 1. In-game telemetry (one-time)
+### F1 25 / F1 24 / F1 23
+
+#### 1. In-game telemetry (one-time)
 
 In F1 25, go to **Settings → Telemetry Settings** and configure:
 
@@ -55,7 +62,7 @@ In F1 25, go to **Settings → Telemetry Settings** and configure:
 | UDP Port       | **20777**     |
 | Broadcast Mode | **Off**       |
 
-### 2. Launch the app
+#### 2. Launch the app
 
 **Windows** — double-click `launch_windows.bat`
 
@@ -76,11 +83,32 @@ python3 F1_lap_tracker.py
 
 All launchers automatically open **http://localhost:5000** in your default browser once the server is ready.
 
+### iRacing
+
+#### 1. Install pyirsdk (one-time, Windows only)
+
+```bash
+pip install pyirsdk
+```
+
+#### 2. Launch the app
+
+Same launchers as above. At startup you'll see:
+```
+🏁  iRacing source active (waiting for iRacing...)
+```
+
+#### 3. Start iRacing and load into a session
+
+Once you're on track the dashboard status indicator switches to **iRacing — LIVE** and data populates automatically.
+
+> iRacing and F1 can both be set up at the same time. If F1 UDP packets arrive they take priority; if only iRacing is running it connects instead.
+
 -----
 
 ## Usage
 
-Start the launcher before or after launching F1 25 — order doesn't matter. Once the game starts broadcasting telemetry (typically when you enter a session), the dashboard status indicator will switch to **LIVE TELEMETRY** and data will begin populating automatically.
+Start the launcher before or after launching your sim — order doesn't matter. Once the game starts broadcasting telemetry (typically when you enter a session), the dashboard status indicator will switch to **LIVE TELEMETRY** (F1) or **iRacing — LIVE** and data will begin populating automatically.
 
 ### Header controls
 
@@ -217,19 +245,26 @@ The app exposes a small REST API you can query directly:
 
 ## How It Works
 
-F1 25 broadcasts UDP packets on your local network containing real-time telemetry data. This app runs two threads simultaneously:
+The app auto-detects which sim is running and reads telemetry from it:
 
-- **UDP listener** on port `20777` — parses six packet types:
-  - Packet ID 0 (Motion) — car position (X/Z) and G-forces for the track map and G-force circle
-  - Packet ID 1 (Session Data) — track, session type, weather
-  - Packet ID 2 (Lap Data) — lap times and sector splits
-  - Packet ID 3 (Event) — fastest lap detection (FTLP event)
-  - Packet ID 6 (Car Telemetry) — speed, throttle, brake, gear, steering, RPM, and rev-lights percent for telemetry charts and the live rev-lights panel
-  - Packet ID 7 (Car Status) — tyre compound
-  - Packet ID 8 (Final Classification) — race finishing position, points, and result status
+### F1 25 / F1 24 / F1 23
+F1 25 broadcasts UDP packets on your local network. The app parses:
+- Packet ID 0 (Motion) — car position (X/Z) and G-forces
+- Packet ID 1 (Session Data) — track, session type, weather
+- Packet ID 2 (Lap Data) — lap times and sector splits
+- Packet ID 3 (Event) — fastest lap detection
+- Packet ID 6 (Car Telemetry) — speed, throttle, brake, gear, steering, RPM, rev-lights
+- Packet ID 7 (Car Status) — tyre compound
+- Packet ID 8 (Final Classification) — race finishing position and points
+
+### iRacing
+iRacing exposes telemetry through a Windows shared memory API (the iRacing SDK). The app reads this at 30 Hz via `pyirsdk`, mapping speed, throttle, brake, gear, RPM, G-forces, tyre wear, and fuel directly to the same dashboard data the F1 source produces. Sector times are derived from lap distance percentage as the car crosses the sector boundaries defined in iRacing's session data. No UDP configuration is needed.
+
+### Storage and server
+Both sources share the same storage and server:
 - **HTTP server** on port `5000` — serves the dashboard and API endpoints; the browser polls `/api/state` every second
-
-Each completed lap is written to `f1_laps.db` (SQLite) immediately. If the lap beats the all-time best for that track and session type, the `personal_bests` table is updated at the same time. When a Final Classification packet arrives at the end of a race, the result is written to the `race_results` table.
+- Each completed lap is written to `f1_laps.db` (SQLite) immediately, tagged with the active sim
+- Personal bests are tracked per sim — F1 and iRacing PBs for the same track are stored separately and never overwrite each other
 
 -----
 
@@ -253,9 +288,15 @@ If you want to host a private leaderboard for your own group, see [HOSTING.md](H
 
 **Dashboard shows "Waiting for telemetry…"**
 
+*F1:*
 - Confirm UDP Telemetry is set to **On** in-game
 - Confirm the IP is `127.0.0.1` and port is `20777`
 - Make sure you're in an active session (not the main menu)
+
+*iRacing:*
+- Confirm `pyirsdk` is installed (`pip install pyirsdk`) and the startup banner shows `🏁 iRacing source active`
+- Make sure you are on track (iRacing only sends telemetry once the car is out of the garage)
+- iRacing support is Windows-only
 
 **AI Debrief button doesn't appear**
 
@@ -283,8 +324,10 @@ If you want to host a private leaderboard for your own group, see [HOSTING.md](H
 
 ## Notes
 
-- This app is built for **F1 25** but is compatible with F1 2023 and F1 2024 using the same UDP format.
-- Console versions (PlayStation, Xbox) can also broadcast telemetry to a PC on the same network — set the UDP IP to your PC's local IP instead of `127.0.0.1` and ensure both devices are on the same network.
+- Built for **F1 25** and compatible with F1 2023/2024 using the same UDP format.
+- **iRacing** support requires `pyirsdk` and Windows. The app runs in F1-only mode on macOS and Linux without it.
+- iRacing sector times are approximate — derived from lap distance percentage at sector boundary crossings rather than explicit game packets.
+- Console versions of F1 (PlayStation, Xbox) can also broadcast telemetry to a PC on the same network — set the UDP IP to your PC's local IP instead of `127.0.0.1` and ensure both devices are on the same network.
 - No lap or session data is sent externally unless you enable the leaderboard opt-in toggle. The AI debrief sends only session metadata and lap times (no personal information) to the shared backend.
 
 -----

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Pitwall IQ — F1 Lap Tracker</title>
+  <title>Pitwall IQ — F1 &amp; iRacing Lap Tracker</title>
   <style>
     :root {
       --accent: #00b86b;
@@ -451,9 +451,9 @@
 
 <!-- HERO -->
 <section class="hero">
-  <div class="badge">F1 25 &bull; F1 24 &bull; F1 23</div>
+  <div class="badge">F1 25 &bull; F1 24 &bull; F1 23 &bull; iRacing</div>
   <h1>Your personal<br><em>race engineer</em><br>in the browser</h1>
-  <p>Pitwall IQ captures every lap time, sector split, and tyre stint automatically via F1's built-in UDP telemetry — no mods, no middleware, no fuss.</p>
+  <p>Pitwall IQ captures every lap time, sector split, and tyre stint automatically — from F1 25/24/23 via UDP telemetry or iRacing via shared memory. No mods, no middleware, no fuss.</p>
   <div class="hero-actions">
     <a href="https://github.com/brianturner005/f1_lap_tracker#setup" class="btn btn-primary">Get started free</a>
     <a href="https://github.com/brianturner005/f1_lap_tracker" class="btn btn-outline">View on GitHub</a>
@@ -626,12 +626,12 @@
   <div class="container">
     <p class="section-label">How it works</p>
     <h2>Up and running in minutes</h2>
-    <p class="section-intro" style="margin-bottom: 2.5rem;">Pitwall IQ uses F1 25's built-in UDP telemetry — no mods or extra software required.</p>
+    <p class="section-intro" style="margin-bottom: 2.5rem;">Pitwall IQ auto-detects your sim and connects automatically — F1 25/24/23 via built-in UDP telemetry, iRacing via shared memory. No mods or extra software required.</p>
     <div class="steps">
       <div class="step">
         <div class="step-num">01</div>
-        <h3>Enable UDP in-game</h3>
-        <p>Go to Settings → Telemetry Settings. Set UDP Telemetry to On, IP to 127.0.0.1, and port to 20777. One-time setup.</p>
+        <h3>Enable telemetry</h3>
+        <p><strong>F1:</strong> Settings → Telemetry Settings — UDP On, IP 127.0.0.1, port 20777. One-time setup.<br><br><strong>iRacing:</strong> Run <code>pip install pyirsdk</code> once. No in-game config needed.</p>
       </div>
       <div class="step">
         <div class="step-num">02</div>
@@ -641,7 +641,7 @@
       <div class="step">
         <div class="step-num">03</div>
         <h3>Enter a session</h3>
-        <p>Load into any session in F1 25. The dashboard status switches to <strong>LIVE TELEMETRY</strong> and data starts populating immediately.</p>
+        <p>Load into any session in F1 25 or iRacing. The dashboard status switches to <strong>LIVE TELEMETRY</strong> or <strong>iRacing — LIVE</strong> and data starts populating immediately.</p>
       </div>
       <div class="step">
         <div class="step-num">04</div>
@@ -679,12 +679,21 @@
     <p class="section-label">Requirements</p>
     <div class="req-box">
       <div>
-        <h3>Core app</h3>
+        <h3>F1 25 / 24 / 23</h3>
         <ul>
           <li>Python 3.8 or newer</li>
           <li>F1 25, F1 24, or F1 23 on PC</li>
           <li>No third-party packages</li>
           <li>Works fully offline</li>
+        </ul>
+      </div>
+      <div>
+        <h3>iRacing</h3>
+        <ul>
+          <li>Windows only</li>
+          <li>pip install pyirsdk (one-time)</li>
+          <li>No in-game config needed</li>
+          <li>Separate PBs &amp; leaderboard</li>
         </ul>
       </div>
       <div>
@@ -700,7 +709,7 @@
         <ul>
           <li>Opt-in via toggle</li>
           <li>No account or sign-up</li>
-          <li>Console versions supported</li>
+          <li>Per-sim leaderboards</li>
         </ul>
       </div>
     </div>
@@ -721,7 +730,7 @@
 
 <!-- FOOTER -->
 <footer>
-  <p>Pitwall IQ &mdash; open source F1 lap tracker &bull; <a href="https://github.com/brianturner005/f1_lap_tracker">GitHub</a></p>
+  <p>Pitwall IQ &mdash; open source F1 &amp; iRacing lap tracker &bull; <a href="https://github.com/brianturner005/f1_lap_tracker">GitHub</a></p>
   <p style="margin-top: 0.4rem;">Not affiliated with Formula 1, FIA, or EA Sports.</p>
 </footer>
 

--- a/iracing_source.py
+++ b/iracing_source.py
@@ -1,0 +1,495 @@
+"""
+iRacing telemetry source for Pitwall IQ.
+
+Reads from iRacing's shared memory API and writes to the shared state dict
+in the same format as the F1 UDP listener, so the dashboard works unchanged.
+
+Requires pyirsdk on Windows:
+    pip install pyirsdk
+
+The app works without this file / without pyirsdk installed — F1 support is
+unaffected. This module is imported lazily at startup and silently skipped if
+pyirsdk is not available.
+"""
+
+import logging
+import threading
+import time
+from datetime import datetime
+
+try:
+    import irsdk
+    IRACING_AVAILABLE = True
+except ImportError:
+    IRACING_AVAILABLE = False
+
+log = logging.getLogger(__name__)
+
+_SESSION_TYPE_MAP = {
+    "offline testing": "Practice",
+    "open practice":   "Practice",
+    "lone qualifying": "Qualifying",
+    "open qualifying": "Qualifying",
+    "lone time trial": "Time Trial",
+    "open time trial": "Time Trial",
+    "warmup":          "Warm Up",
+    "race":            "Race",
+}
+
+_SKIES_MAP = {0: "Clear", 1: "Partly Cloudy", 2: "Mostly Cloudy", 3: "Overcast"}
+
+_TRACE_MIN_DIST = 3.0
+_TRACE_MAX_PTS  = 4000
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sec_to_laptime(s: float) -> str:
+    if s is None or s <= 0:
+        return "–:–.—"
+    ms = int(round(s * 1000))
+    m   = ms // 60000
+    sec = (ms % 60000) // 1000
+    mil = ms % 1000
+    return f"{m}:{sec:02d}.{mil:03d}"
+
+
+def _ms_to_laptime(ms: int) -> str:
+    return _sec_to_laptime(ms / 1000.0) if ms else "–:–.—"
+
+
+def _delta_str(ms: int, best_ms: int) -> str:
+    if ms is None or best_ms is None:
+        return ""
+    diff = ms - best_ms
+    if diff == 0:
+        return "BEST"
+    sign = "+" if diff > 0 else "-"
+    return f"{sign}{abs(diff) / 1000.0:.3f}s"
+
+
+def _safe(ir, key, default=None):
+    """Safely read an irsdk variable, returning *default* on any error."""
+    try:
+        val = ir[key]
+        return val if val is not None else default
+    except Exception:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# IRacingSource
+# ---------------------------------------------------------------------------
+
+class IRacingSource:
+    """Polls iRacing shared memory at 30 Hz and updates the Pitwall IQ state."""
+
+    POLL_INTERVAL = 1.0 / 30  # seconds
+
+    def __init__(self, state, state_lock, callbacks):
+        """
+        *callbacks* must contain callable values for these keys:
+          db_create_session, db_close_session, db_save_lap,
+          db_get_track_pb, db_upsert_track_pb, lb_post
+        """
+        self._state = state
+        self._lock  = state_lock
+        self._cb    = callbacks
+        self._ir    = None
+
+        # Session state
+        self._session_id  = None
+        self._session_key = None   # (track, session_type) — detect track/type changes
+
+        # Lap state
+        self._last_lap_time = None  # last seen LapLastLapTime value (seconds)
+        self._lap_num       = 0
+        self._lap_trace     = []
+
+        # Sector tracking
+        self._sector_boundaries = [0.333, 0.666]  # [end-of-S1-pct, end-of-S2-pct]
+        self._in_sector    = 0      # 0, 1, or 2
+        self._s1_end_time  = None   # LapCurrentLapTime (s) when S1 ended
+        self._s2_end_time  = None   # LapCurrentLapTime (s) when S2 ended
+        self._last_dist    = None   # last LapDistPct, used for wrap detection
+
+    # ── Public ────────────────────────────────────────────────────────────────
+
+    def start(self):
+        t = threading.Thread(target=self._run, daemon=True)
+        t.start()
+
+    # ── Main loop ─────────────────────────────────────────────────────────────
+
+    def _run(self):
+        self._ir = irsdk.IRSDK()
+        was_connected = False
+
+        while True:
+            try:
+                connected = (self._ir.is_initialized and self._ir.is_connected)
+                if not connected:
+                    if self._ir.startup():
+                        connected = True
+                    else:
+                        if was_connected:
+                            self._on_disconnect()
+                            was_connected = False
+                        time.sleep(2.0)
+                        continue
+
+                if not was_connected:
+                    self._on_connect()
+                    was_connected = True
+
+                self._ir.freeze_var_buffer_latest()
+                self._process_frame()
+
+            except Exception as exc:
+                log.debug("iRacing source error: %s", exc)
+                time.sleep(1.0)
+                continue
+
+            time.sleep(self.POLL_INTERVAL)
+
+    # ── Connection lifecycle ──────────────────────────────────────────────────
+
+    def _on_connect(self):
+        log.info("iRacing connected")
+        self._load_sector_boundaries()
+        with self._lock:
+            self._state["iracing_connected"] = True
+            # Only take over from F1 if F1 is not actively connected
+            if not self._state.get("udp_connected"):
+                self._state["sim"] = "iRacing"
+                self._state["udp_connected"] = True
+
+    def _on_disconnect(self):
+        log.info("iRacing disconnected")
+        if self._session_id is not None:
+            self._cb["db_close_session"](self._session_id)
+            self._session_id  = None
+            self._session_key = None
+        with self._lock:
+            self._state["iracing_connected"] = False
+            if self._state.get("sim") == "iRacing":
+                self._state["udp_connected"] = False
+
+    # ── Sector boundary loading ───────────────────────────────────────────────
+
+    def _load_sector_boundaries(self):
+        """Parse sector boundary percentages from iRacing session YAML."""
+        try:
+            sectors = (self._ir["WeekendInfo"] or {}).get("TrackSectors", [])
+            pcts = []
+            for s in sectors:
+                try:
+                    pct = float(s.get("SectorStartPct", 0))
+                    if pct > 0:
+                        pcts.append(pct)
+                except (TypeError, ValueError):
+                    pass
+            pcts.sort()
+            if len(pcts) >= 2:
+                self._sector_boundaries = pcts[:2]
+            elif len(pcts) == 1:
+                # Only one interior boundary found — split the remaining third evenly
+                self._sector_boundaries = [pcts[0], pcts[0] + (1.0 - pcts[0]) / 2]
+            # else keep the default [0.333, 0.666]
+        except Exception as exc:
+            log.debug("Could not load sector boundaries: %s", exc)
+
+    # ── Per-frame processing ──────────────────────────────────────────────────
+
+    def _process_frame(self):
+        ir = self._ir
+
+        # Skip when player is not on track
+        if not _safe(ir, "IsOnTrack", False) or _safe(ir, "IsInGarage", True):
+            return
+
+        # ── Session info ──────────────────────────────────────────────────────
+        track = str(
+            _safe(ir, "TrackDisplayName") or _safe(ir, "TrackName") or "Unknown"
+        ).strip() or "Unknown"
+
+        session_num = int(_safe(ir, "SessionNum", 0) or 0)
+        try:
+            sessions  = ir["SessionInfo"]["Sessions"]
+            raw_type  = (sessions[session_num].get("SessionType") or "").lower().strip()
+            session_type = _SESSION_TYPE_MAP.get(raw_type, raw_type.title() or "Practice")
+        except Exception:
+            session_type = "Practice"
+
+        skies   = int(_safe(ir, "Skies", 0) or 0)
+        weather = _SKIES_MAP.get(skies, "Clear")
+
+        # ── DB session lifecycle ──────────────────────────────────────────────
+        session_key = (track, session_type)
+        if self._session_key != session_key:
+            if self._session_id is not None:
+                self._cb["db_close_session"](self._session_id)
+            started_at = datetime.now().isoformat()
+            self._session_id = self._cb["db_create_session"](
+                track, session_type, weather, started_at, sim="iRacing"
+            )
+            self._session_key = session_key
+            self._last_lap_time = None
+            self._lap_num = 0
+
+            pb = self._cb["db_get_track_pb"](track, session_type, sim="iRacing")
+            with self._lock:
+                if self._state.get("sim") == "iRacing":
+                    self._state["track_pb_ms"]       = pb["lap_time_ms"] if pb else None
+                    self._state["track_pb_time"]      = pb["lap_time"]    if pb else None
+                    self._state["track_pb_compound"]  = pb.get("compound", "") if pb else None
+                    self._state["session"]["track"]        = track
+                    self._state["session"]["session_type"] = session_type
+                    self._state["session"]["weather"]      = weather
+                    self._state["session"]["started_at"]   = started_at
+                    self._state["current_session_id"] = self._session_id
+                    self._state["laps"]         = []
+                    self._state["best_lap_ms"]  = None
+                    self._state["best_lap_num"] = None
+
+        # ── Live telemetry ────────────────────────────────────────────────────
+        speed_kmh = int((_safe(ir, "Speed", 0.0) or 0.0) * 3.6)
+        throttle  = float(_safe(ir, "Throttle", 0.0) or 0.0)
+        brake     = float(_safe(ir, "Brake",    0.0) or 0.0)
+        gear      = int(_safe(ir, "Gear", 0) or 0)
+        rpm_val   = float(_safe(ir, "RPM", 0.0) or 0.0)
+
+        # Steering: iRacing gives radians; normalise to -1.0 … +1.0
+        steer_rad = float(_safe(ir, "SteeringWheelAngle", 0.0) or 0.0)
+        steer_max = float(_safe(ir, "SteeringWheelAngleMax", 1.5708) or 1.5708)
+        steer = round(max(-1.0, min(1.0, steer_rad / steer_max if steer_max else steer_rad)), 3)
+
+        # G-forces: iRacing gives m/s², convert to G
+        lat_g = round(float(_safe(ir, "LatAccel", 0.0) or 0.0) / 9.81, 3)
+        lon_g = round(float(_safe(ir, "LonAccel", 0.0) or 0.0) / 9.81, 3)
+
+        # Rev lights: derive 0-100% from shift RPM band
+        sl_first = float(_safe(ir, "PlayerCarSLFirstRPM", 0.0) or 0.0)
+        sl_last  = float(_safe(ir, "PlayerCarSLLastRPM",  0.0) or 0.0)
+        if sl_last > sl_first > 0:
+            rev_pct = int(max(0, min(100, (rpm_val - sl_first) / (sl_last - sl_first) * 100)))
+        else:
+            rev_pct = 0
+
+        # Position / lap counters
+        player_idx = int(_safe(ir, "PlayerCarIdx", 0) or 0)
+        positions  = _safe(ir, "CarIdxPosition", None)
+        position   = int(positions[player_idx]) if (positions and player_idx < len(positions)) else 0
+        total_laps = int(_safe(ir, "SessionLapsTotal", 0) or 0)
+        if total_laps >= 32767:
+            total_laps = 0  # iRacing uses 32767 for "unlimited"
+        current_lap = int(_safe(ir, "Lap", 1) or 1)
+
+        # Tyre wear: iRacing gives *remaining* fraction (1.0 = new); convert to used %
+        # Map to [RL, RR, FL, FR] to match F1 layout
+        tw_lf = float(_safe(ir, "TireWearLF", 1.0) or 1.0)
+        tw_rf = float(_safe(ir, "TireWearRF", 1.0) or 1.0)
+        tw_lr = float(_safe(ir, "TireWearLR", 1.0) or 1.0)
+        tw_rr = float(_safe(ir, "TireWearRR", 1.0) or 1.0)
+        tyre_wear = [
+            round((1.0 - tw_lr) * 100),
+            round((1.0 - tw_rr) * 100),
+            round((1.0 - tw_lf) * 100),
+            round((1.0 - tw_rf) * 100),
+        ]
+
+        fuel = round(float(_safe(ir, "FuelLevel", 0.0) or 0.0), 2)
+
+        # World position for track map
+        wx = _safe(ir, "CarIdxWorldPosX", None)
+        wz = _safe(ir, "CarIdxWorldPosZ", None)
+        car_pos = None
+        if wx and wz and player_idx < len(wx):
+            car_pos = {"x": round(float(wx[player_idx]), 1),
+                       "z": round(float(wz[player_idx]), 1)}
+
+        # Sector tracking and trace updates
+        dist_pct      = float(_safe(ir, "LapDistPct", 0.0) or 0.0)
+        cur_lap_time  = float(_safe(ir, "LapCurrentLapTime", 0.0) or 0.0)
+        current_sector = self._update_sectors(dist_pct, cur_lap_time)
+
+        if car_pos:
+            trace = self._lap_trace
+            if len(trace) < _TRACE_MAX_PTS:
+                prev = trace[-1] if trace else None
+                if not prev or (abs(car_pos["x"] - prev["x"]) + abs(car_pos["z"] - prev["z"])) >= _TRACE_MIN_DIST:
+                    trace.append({
+                        "x": car_pos["x"], "z": car_pos["z"],
+                        "speed": speed_kmh, "sector": current_sector,
+                        "throttle": round(throttle, 3), "brake": round(brake, 3),
+                        "steer": steer, "gear": gear, "rpm": int(rpm_val),
+                        "gLat": lat_g, "gLon": lon_g,
+                    })
+
+        # Lap completion detection
+        last_lap_s = float(_safe(ir, "LapLastLapTime", -1.0) or -1.0)
+        if last_lap_s > 0 and last_lap_s != self._last_lap_time:
+            self._on_lap_complete(last_lap_s, track, session_type)
+            self._last_lap_time = last_lap_s
+
+        # ── Write shared state ────────────────────────────────────────────────
+        with self._lock:
+            if self._state.get("sim") != "iRacing":
+                return  # F1 took over — don't overwrite
+            self._state["udp_connected"]  = True
+            self._state["car_speed"]      = speed_kmh
+            self._state["car_throttle"]   = round(throttle, 3)
+            self._state["car_brake"]      = round(brake, 3)
+            self._state["car_steer"]      = steer
+            self._state["car_gear"]       = gear
+            self._state["car_rpm"]        = int(rpm_val)
+            self._state["rev_lights_pct"] = rev_pct
+            self._state["g_lat"]          = lat_g
+            self._state["g_lon"]          = lon_g
+            self._state["player_position"] = position
+            self._state["total_laps"]     = total_laps
+            self._state["current_lap"]    = current_lap
+            self._state["tyre_wear"]      = tyre_wear
+            self._state["fuel_in_tank"]   = fuel
+            self._state["current_sector"] = current_sector
+            self._state["session"]["weather"] = weather
+            if car_pos:
+                self._state["car_pos"] = car_pos
+            self._state["lap_trace"] = list(self._lap_trace)
+
+    # ── Sector tracking ───────────────────────────────────────────────────────
+
+    def _update_sectors(self, dist_pct: float, cur_lap_time: float) -> int:
+        """
+        Track sector crossings via LapDistPct.
+        Returns the current sector index (0=S1, 1=S2, 2=S3).
+        """
+        b1, b2 = self._sector_boundaries
+
+        # Detect lap wrap (dist_pct resets from ~1.0 back to ~0.0)
+        if self._last_dist is not None and dist_pct < 0.1 and self._last_dist > 0.9:
+            self._in_sector   = 0
+            self._s1_end_time = None
+            self._s2_end_time = None
+            self._lap_trace   = []
+
+        if self._in_sector == 0 and dist_pct >= b1:
+            self._s1_end_time = cur_lap_time
+            self._in_sector   = 1
+        elif self._in_sector == 1 and dist_pct >= b2:
+            self._s2_end_time = cur_lap_time
+            self._in_sector   = 2
+
+        self._last_dist = dist_pct
+        return self._in_sector
+
+    # ── Lap completion ────────────────────────────────────────────────────────
+
+    def _on_lap_complete(self, lap_secs: float, track: str, session_type: str):
+        lap_ms = int(round(lap_secs * 1000))
+        if not (30_000 <= lap_ms <= 600_000):
+            return  # sanity check — ignore implausible times
+
+        self._lap_num += 1
+        lap_time_str = _sec_to_laptime(lap_secs)
+        timestamp    = datetime.now().isoformat()
+
+        # Derive sector times from recorded crossing timestamps
+        s1_ms = int(round(self._s1_end_time * 1000))  if self._s1_end_time else None
+        s2_ms = int(round((self._s2_end_time - self._s1_end_time) * 1000)) \
+                if (self._s2_end_time and self._s1_end_time) else None
+        s3_ms = int(round((lap_secs - self._s2_end_time) * 1000)) \
+                if self._s2_end_time else None
+
+        saved_trace = list(self._lap_trace)
+
+        # Snapshot state values we need outside the lock
+        with self._lock:
+            best_ms      = self._state.get("best_lap_ms")
+            track_pb_ms  = self._state.get("track_pb_ms")
+            opt_in       = self._state.get("leaderboard_opt_in", False)
+            player_id    = self._state.get("player_id", "")
+            display_name = self._state.get("display_name", "Anonymous")
+
+        is_best     = best_ms is None or lap_ms < best_ms
+        is_track_pb = track_pb_ms is None or lap_ms < track_pb_ms
+
+        # Update session best
+        if is_best:
+            with self._lock:
+                self._state["best_lap_ms"]  = lap_ms
+                self._state["best_lap_num"] = self._lap_num
+
+        ref_ms = best_ms if (best_ms and not is_best) else lap_ms
+        delta  = "PB!" if is_track_pb else _delta_str(lap_ms, ref_ms)
+
+        lap_record = {
+            "lap_num":     self._lap_num,
+            "lap_time_ms": lap_ms,
+            "lap_time":    lap_time_str,
+            "s1_ms":  s1_ms, "s1": _ms_to_laptime(s1_ms) if s1_ms else None,
+            "s2_ms":  s2_ms, "s2": _ms_to_laptime(s2_ms) if s2_ms else None,
+            "s3_ms":  s3_ms, "s3": _ms_to_laptime(s3_ms) if s3_ms else None,
+            "invalid":     False,
+            "compound":    "",
+            "timestamp":   timestamp,
+            "is_track_pb": is_track_pb,
+            "is_best":     is_best,
+            "delta":       delta,
+            "telem":       {},
+        }
+
+        # Persist to DB
+        if self._session_id is not None:
+            self._cb["db_save_lap"](self._session_id, lap_record, trace=saved_trace or None)
+
+        # Update track PB
+        if is_track_pb:
+            self._cb["db_upsert_track_pb"](
+                track, session_type, lap_ms, lap_time_str, "",
+                self._session_id, timestamp, sim="iRacing",
+            )
+            with self._lock:
+                self._state["track_pb_ms"]      = lap_ms
+                self._state["track_pb_time"]     = lap_time_str
+                self._state["track_pb_compound"] = ""
+                self._state["track_outline"]     = saved_trace
+
+            if opt_in and player_id:
+                self._cb["lb_post"]({
+                    "player_id":    player_id,
+                    "display_name": display_name,
+                    "track":        track,
+                    "session_type": session_type,
+                    "lap_time_ms":  lap_ms,
+                    "lap_time":     lap_time_str,
+                    "compound":     "",
+                    "submitted_at": timestamp,
+                    "sim":          "iRacing",
+                })
+
+        # Append to live laps list
+        with self._lock:
+            if self._state.get("sim") == "iRacing":
+                self._state["laps"].append(lap_record)
+                self._state["track_outline"] = saved_trace
+                self._state["last_sector"]   = [s1_ms, s2_ms, s3_ms]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def start_iracing_source(state, state_lock, callbacks):
+    """
+    Start the iRacing telemetry source thread.
+
+    Returns True if pyirsdk is available and the thread was started.
+    Returns False if pyirsdk is not installed (F1 support is unaffected).
+    """
+    if not IRACING_AVAILABLE:
+        return False
+    IRacingSource(state, state_lock, callbacks).start()
+    return True

--- a/leaderboard_api/function_app.py
+++ b/leaderboard_api/function_app.py
@@ -152,6 +152,9 @@ def _handle_submit(body) -> func.HttpResponse:
     lap_time: str = str(body["lap_time"]).strip()
     compound: str = str(body.get("compound", "")).strip()
     submitted_at: str = str(body["submitted_at"]).strip()
+    sim: str = str(body.get("sim", "F1")).strip()
+    if sim not in ("F1", "iRacing"):
+        sim = "F1"
 
     _VALID_COMPOUNDS = {"Soft", "Medium", "Hard", "Inter", "Wet", ""}
 
@@ -178,7 +181,9 @@ def _handle_submit(body) -> func.HttpResponse:
         return _error("Invalid compound value.")
 
     doc_id = f"{player_id}_{track}_{session_type}".replace(" ", "_")
-    partition_key_value = f"{track}|{session_type}"
+    # F1 keeps the original partition key format for backward compatibility;
+    # other sims get a prefixed namespace so times never intermix.
+    partition_key_value = f"{track}|{session_type}" if sim == "F1" else f"{sim}|{track}|{session_type}"
 
     document = {
         "id": doc_id,
@@ -248,11 +253,14 @@ def leaderboard(req: func.HttpRequest) -> func.HttpResponse:
     track: str = req.route_params.get("track", "").strip()
     session_type: str = req.route_params.get("session_type", "").strip()
     player_id: str = req.params.get("player_id", "").strip()
+    sim: str = req.params.get("sim", "F1").strip()
+    if sim not in ("F1", "iRacing"):
+        sim = "F1"
 
     if not track or not session_type:
         return _error("track and session_type path parameters are required.")
 
-    partition_key_value = f"{track}|{session_type}"
+    partition_key_value = f"{track}|{session_type}" if sim == "F1" else f"{sim}|{track}|{session_type}"
     container = _get_container(LEADERBOARD_CONTAINER)
 
     top_query = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# iRacing telemetry support (Windows only — not required for F1 mode)
+# Install with: pip install pyirsdk
+pyirsdk>=1.4.0

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1625,7 +1625,7 @@ function render(d) {
   if (d.udp_connected) {
     dot.className = 'status-dot live';
     stxt.className = 'status-text live';
-    stxt.textContent = 'LIVE TELEMETRY';
+    stxt.textContent = d.sim === 'iRacing' ? 'iRacing — LIVE' : 'LIVE TELEMETRY';
   } else {
     dot.className = 'status-dot';
     stxt.className = 'status-text';


### PR DESCRIPTION
Adds a pluggable telemetry source architecture so Pitwall IQ works
with iRacing alongside F1 25/24/23.

- iracing_source.py: new adapter that reads iRacing shared memory via
  pyirsdk at 30 Hz, maps telemetry to the existing state dict, handles
  lap completion and sector tracking (via LapDistPct + session YAML
  sector boundaries), and submits PBs to the leaderboard
- F1_lap_tracker.py: DB migrations add a `sim` column to sessions,
  personal_bests (PK extended to include sim), and race_results;
  db_create_session / db_get_track_pb / db_upsert_track_pb accept a
  sim= kwarg (default 'F1'); startup wires in the iRacing source if
  pyirsdk is installed; state["sim"] tracks the active source
- dashboard.html: status indicator shows "iRacing — LIVE" when iRacing
  is the active source; compound pill already handles empty compounds
- leaderboard_api/function_app.py: submit and fetch endpoints accept
  optional sim= parameter; iRacing times use a prefixed partition key
  (iRacing|track|session) so F1 and iRacing leaderboards are separate;
  F1 partition key format unchanged for backward compatibility
- requirements.txt: lists pyirsdk as optional dependency for iRacing
  support (F1 mode requires no third-party packages)

https://claude.ai/code/session_0142GXxxzS28rnyVN4b7eTps