### PR TITLE
fix: iRacing connection + security hardening

### DIFF
--- a/iracing_source.py
+++ b/iracing_source.py
@@ -129,16 +129,20 @@ class IRacingSource:
 
         while True:
             try:
-                connected = (self._ir.is_initialized and self._ir.is_connected)
+                # startup() return value is unreliable across pyirsdk versions
+                # (returns None in 2.x, bool in 1.x). Call it when not yet
+                # initialized, then check is_connected independently.
+                if not self._ir.is_initialized:
+                    self._ir.startup()
+
+                connected = bool(self._ir.is_connected)
+
                 if not connected:
-                    if self._ir.startup():
-                        connected = True
-                    else:
-                        if was_connected:
-                            self._on_disconnect()
-                            was_connected = False
-                        time.sleep(2.0)
-                        continue
+                    if was_connected:
+                        self._on_disconnect()
+                        was_connected = False
+                    time.sleep(2.0)
+                    continue
 
                 if not was_connected:
                     self._on_connect()
@@ -148,7 +152,7 @@ class IRacingSource:
                 self._process_frame()
 
             except Exception as exc:
-                log.debug("iRacing source error: %s", exc)
+                log.warning("iRacing source error: %s", exc)
                 time.sleep(1.0)
                 continue
 
@@ -211,9 +215,14 @@ class IRacingSource:
             return
 
         # ── Session info ──────────────────────────────────────────────────────
-        track = str(
-            _safe(ir, "TrackDisplayName") or _safe(ir, "TrackName") or "Unknown"
-        ).strip() or "Unknown"
+        # Track name lives in the WeekendInfo YAML block, not as a telemetry var.
+        try:
+            wi = ir["WeekendInfo"] or {}
+            track = str(
+                wi.get("TrackDisplayName") or wi.get("TrackName") or "Unknown"
+            ).strip() or "Unknown"
+        except Exception:
+            track = "Unknown"
 
         session_num = int(_safe(ir, "SessionNum", 0) or 0)
         try:


### PR DESCRIPTION
## iRacing fix
`startup()` returns `None` in pyirsdk 2.x so the old `if ir.startup():` check always evaluated false. Fixed by calling `startup()` unconditionally when not initialized and checking `is_connected` separately. Also fixes track name lookup (WeekendInfo YAML) and promotes iRacing errors from debug to warning.

## Security fixes (addresses issue #98 + full audit)

| Area | Fix |
|---|---|
| **Stored XSS** | `e.lap_time`, `pb.track`, `pb.lap_time`, session track/type/weather/dates now wrapped with `esc()` in `dashboard.html` |
| **Path traversal** | `/api/track-svg/` now checks the requested name against the `TRACK_SVG` allowlist before serving any file |
| **Prompt injection** | All per-lap fields inserted into the AI debrief prompt now pass through `_clean()` (strips control characters) |
| **display_name XSS** | Azure Function now blocks HTML special chars (`<>"'&\``) in `display_name` at submission time |
| **X-Forwarded-For** | IP rate limit now uses the rightmost (last) IP — the first entry is attacker-controllable |
| **submitted_at** | Length-capped at 40 chars in the Azure Function |
| **Content-Length** | POST endpoints in `F1_lap_tracker.py` now reject bodies over 8 KB (413) |
| **player_id** | UUID regex validated before forwarding to the leaderboard backend |
| **Bandit B608** | Added `# nosec B608` to parameterized queries that triggered false positives — closes #98 |

https://claude.ai/code/session_0142GXxxzS28rnyVN4b7eTps