### PR TITLE
fix: iRacing telemetry charts + security hardening (v2.0.1)

### DIFF
--- a/iracing_source.py
+++ b/iracing_source.py
@@ -13,6 +13,7 @@ pyirsdk is not available.
 """
 
 import logging
+import math
 import threading
 import time
 from datetime import datetime
@@ -311,31 +312,34 @@ class IRacingSource:
 
         fuel = round(float(_safe(ir, "FuelLevel", 0.0) or 0.0), 2)
 
-        # World position for track map
-        wx = _safe(ir, "CarIdxWorldPosX", None)
-        wz = _safe(ir, "CarIdxWorldPosZ", None)
-        car_pos = None
-        if wx and wz and player_idx < len(wx):
-            car_pos = {"x": round(float(wx[player_idx]), 1),
-                       "z": round(float(wz[player_idx]), 1)}
-
         # Sector tracking and trace updates
         dist_pct      = float(_safe(ir, "LapDistPct", 0.0) or 0.0)
         cur_lap_time  = float(_safe(ir, "LapCurrentLapTime", 0.0) or 0.0)
         current_sector = self._update_sectors(dist_pct, cur_lap_time)
 
-        if car_pos:
-            trace = self._lap_trace
-            if len(trace) < _TRACE_MAX_PTS:
-                prev = trace[-1] if trace else None
-                if not prev or (abs(car_pos["x"] - prev["x"]) + abs(car_pos["z"] - prev["z"])) >= _TRACE_MIN_DIST:
-                    trace.append({
-                        "x": car_pos["x"], "z": car_pos["z"],
-                        "speed": speed_kmh, "sector": current_sector,
-                        "throttle": round(throttle, 3), "brake": round(brake, 3),
-                        "steer": steer, "gear": gear, "rpm": int(rpm_val),
-                        "gLat": lat_g, "gLon": lon_g,
-                    })
+        # World position for track map — iRacing SDK does not expose CarIdxWorldPos*
+        # so we always fall back to a synthetic circular layout from LapDistPct.
+        # Real coords would need to be integrated from velocity; the circle gives the
+        # dashboard enough x/z data to drive the telemetry charts correctly.
+        _R = 500.0
+        angle = dist_pct * 2 * math.pi
+        car_pos = {
+            "x": round(math.cos(angle) * _R, 1),
+            "z": round(math.sin(angle) * _R, 1),
+        }
+
+        trace = self._lap_trace
+        if len(trace) < _TRACE_MAX_PTS:
+            prev = trace[-1] if trace else None
+            dist_moved = (abs(car_pos["x"] - prev["x"]) + abs(car_pos["z"] - prev["z"])) if prev else _TRACE_MIN_DIST
+            if dist_moved >= _TRACE_MIN_DIST:
+                trace.append({
+                    "x": car_pos["x"], "z": car_pos["z"],
+                    "speed": speed_kmh, "sector": current_sector,
+                    "throttle": round(throttle, 3), "brake": round(brake, 3),
+                    "steer": steer, "gear": gear, "rpm": int(rpm_val),
+                    "gLat": lat_g, "gLon": lon_g,
+                })
 
         # Lap completion detection
         last_lap_s = float(_safe(ir, "LapLastLapTime", -1.0) or -1.0)


### PR DESCRIPTION
## Summary

- **Security hardening** — XSS, path traversal, prompt injection, input validation fixes (addresses issue #98)
- **iRacing telemetry charts fix** — `CarIdxWorldPosX`/`Z` don't exist in the iRacing SDK so `car_pos` was always `None`, meaning the lap trace never populated and all telemetry charts stayed blank. Rev lights and gear worked because they come from direct state values, not the trace. Fixed by deriving a synthetic circular position from `LapDistPct` so the trace always fills in. The track map shows a circle shape rather than the actual track layout; telemetry charts (speed, throttle/brake, gear, steering, G-force) now work correctly.
- **Version bump to 2.0.1**

## Test plan

- [ ] iRacing: telemetry charts populate after the first lap
- [ ] iRacing: rev lights and gear still work
- [ ] F1: no regression in telemetry charts or track map
- [ ] Bandit scan passes (no new B608 findings)

https://claude.ai/code/session_0142GXxxzS28rnyVN4b7eTps

---
_Generated by [Claude Code](https://claude.ai/code/session_0142GXxxzS28rnyVN4b7eTps)_