### PR TITLE
fix: add iRacing session/lap console output and sim-aware no-laps message

### DIFF
--- a/iracing_source.py
+++ b/iracing_source.py
@@ -162,6 +162,7 @@ class IRacingSource:
     # ── Connection lifecycle ──────────────────────────────────────────────────
 
     def _on_connect(self):
+        print("[iRacing] Connected to iRacing SDK")
         log.info("iRacing connected")
         self._load_sector_boundaries()
         with self._lock:
@@ -248,6 +249,7 @@ class IRacingSource:
             self._session_key = session_key
             self._last_lap_time = None
             self._lap_num = 0
+            print(f"[iRacing] Session started — {track} ({session_type})")
 
             pb = self._cb["db_get_track_pb"](track, session_type, sim="iRacing")
             with self._lock:
@@ -402,8 +404,9 @@ class IRacingSource:
 
     def _on_lap_complete(self, lap_secs: float, track: str, session_type: str):
         lap_ms = int(round(lap_secs * 1000))
-        if not (30_000 <= lap_ms <= 600_000):
-            return  # sanity check — ignore implausible times
+        if not (20_000 <= lap_ms <= 600_000):
+            print(f"[iRacing] Lap ignored — time {lap_secs:.3f}s is outside valid range (20s–600s)")
+            return
 
         self._lap_num += 1
         lap_time_str = _sec_to_laptime(lap_secs)
@@ -453,6 +456,9 @@ class IRacingSource:
             "delta":       delta,
             "telem":       {},
         }
+
+        pb_marker = " 🏆 Track PB!" if is_track_pb else (" ✓ Session best" if is_best else "")
+        print(f"[iRacing] Lap {self._lap_num}: {lap_time_str}{pb_marker}")
 
         # Persist to DB
         if self._session_id is not None:

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1688,10 +1688,12 @@ function render(d) {
 
   let rows = '';
   if (d.laps.length === 0) {
-    rows = `<tr><td colspan="9" class="waiting"><div class="big-icon">🏎</div>
-      <p>No laps recorded yet.<br>
-      Make sure UDP telemetry is <code>ON</code> in F1 25 settings<br>
-      IP: <code>127.0.0.1</code> &nbsp; Port: <code>20777</code></p></td></tr>`;
+    const noLapMsg = d.sim === 'iRacing'
+      ? `<p>No laps recorded yet.<br>Complete a full lap in iRacing to see your data here.</p>`
+      : `<p>No laps recorded yet.<br>
+         Make sure UDP telemetry is <code>ON</code> in F1 25 settings<br>
+         IP: <code>127.0.0.1</code> &nbsp; Port: <code>20777</code></p>`;
+    rows = `<tr><td colspan="9" class="waiting"><div class="big-icon">🏎</div>${noLapMsg}</td></tr>`;
   } else {
     const reversed = [...d.laps].reverse();
     for (const lap of reversed) {


### PR DESCRIPTION
- Print session start and lap completion to console so users can confirm
  recording is working (previously these were silent log.info calls)
- Print a warning when a lap is ignored due to implausible time (helps
  debug outlap filtering)
- Lowered minimum lap time sanity check from 30s to 20s to cover shorter
  karting and oval tracks
- Dashboard "no laps yet" message now shows sim-appropriate instructions:
  iRacing users see "complete a full lap" instead of F1 UDP setup steps

https://claude.ai/code/session_0142GXxxzS28rnyVN4b7eTps